### PR TITLE
Compact UI

### DIFF
--- a/src/components/ui/TopAppBar.jsx
+++ b/src/components/ui/TopAppBar.jsx
@@ -13,6 +13,7 @@ import {
   Dialog,
   DialogTitle,
   Tooltip,
+  ListItemButton,
   Box
 } from "@mui/material";
 import MenuIcon from "@mui/icons-material/Menu";
@@ -244,25 +245,68 @@ export default function TopAppBar({
                 VIEWS
               </Typography>
             </ListItem>
-            <ListItem button onClick={() => handleViewChange("DriveView")}>
+            <ListItemButton
+              onClick={() => handleViewChange("DriveView")}
+              sx={{
+                bgcolor:
+                  currentView === "DriveView"
+                    ? "rgba(0, 0, 0, 0.2)"
+                    : "transparent",
+              }}
+            >
               <Typography sx={{ color: "black" }}>Drive</Typography>
-            </ListItem>
+            </ListItemButton>
 
-            <ListItem button onClick={() => handleViewChange("ArmView")}>
+            <ListItemButton
+              button
+              onClick={() => handleViewChange("ArmView")}
+              sx={{
+                bgcolor:
+                  currentView === "ArmView"
+                    ? "rgba(0, 0, 0, 0.2)"
+                    : "transparent",
+              }}
+            >
               <Typography sx={{ color: "black" }}>Arm</Typography>
-            </ListItem>
+            </ListItemButton>
 
-            <ListItem button onClick={() => handleViewChange("ScienceView")}>
+            <ListItemButton
+              button
+              onClick={() => handleViewChange("ScienceView")}
+              sx={{
+                bgcolor:
+                  currentView === "ScienceView"
+                    ? "rgba(0, 0, 0, 0.2)"
+                    : "transparent",
+              }}
+            >
               <Typography sx={{ color: "black" }}>Science</Typography>
-            </ListItem>
+            </ListItemButton>
 
-            <ListItem button onClick={() => handleViewChange("AutonomyView")}>
+            <ListItemButton
+              onClick={() => handleViewChange("AutonomyView")}
+              sx={{
+                bgcolor:
+                  currentView === "AutonomyView"
+                    ? "rgba(0, 0, 0, 0.2)"
+                    : "transparent",
+              }}
+            >
               <Typography sx={{ color: "black" }}>Autonomy</Typography>
-            </ListItem>
+            </ListItemButton>
 
-            <ListItem button onClick={() => handleViewChange("ExtrasView")}>
+            <ListItemButton
+              button
+              onClick={() => handleViewChange("ExtrasView")}
+              sx={{
+                bgcolor:
+                  currentView === "ExtrasView"
+                    ? "rgba(0, 0, 0, 0.2)"
+                    : "transparent",
+              }}
+            >
               <Typography sx={{ color: "black" }}>Extras</Typography>
-            </ListItem>
+            </ListItemButton>
           </Box>
           <ListItem>
             <Typography sx={{ color: "black" }} variant="h6">

--- a/src/components/ui/TopAppBar.jsx
+++ b/src/components/ui/TopAppBar.jsx
@@ -95,74 +95,73 @@ export default function TopAppBar({
             component="div"
             sx={{
               pr: 1, // add left padding to align with toolbar items
-              display: { xs: "none", md: "inline-flex" }
+              display: { xs: "none", md: "inline-flex" },
             }}
           >
             Teleoperations
           </Typography>
           <Box sx={{ display: { xs: "none", lg: "inline-flex" } }}>
-
-          {/* Buttons to change between views */}
-          <Button
-            color="inherit"
-            onClick={() => handleViewChange("DriveView")}
-            sx={{
-              bgcolor:
-                currentView === "DriveView"
-                  ? "rgba(255,255,255,0.2)"
-                  : "transparent",
-            }}
-          >
-            Drive
-          </Button>
-          <Button
-            color="inherit"
-            onClick={() => handleViewChange("ArmView")}
-            sx={{
-              bgcolor:
-                currentView === "ArmView"
-                  ? "rgba(255,255,255,0.2)"
-                  : "transparent",
-            }}
-          >
-            Arm
-          </Button>
-          <Button
-            color="inherit"
-            onClick={() => handleViewChange("ScienceView")}
-            sx={{
-              bgcolor:
-                currentView === "ScienceView"
-                  ? "rgba(255,255,255,0.2)"
-                  : "transparent",
-            }}
-          >
-            Science
-          </Button>
-          <Button
-            color="inherit"
-            onClick={() => handleViewChange("AutonomyView")}
-            sx={{
-              bgcolor:
-                currentView === "AutonomyView"
-                  ? "rgba(255,255,255,0.2)"
-                  : "transparent",
-            }}
-          >
-            Autonomy
-          </Button>
-          <Button
-            color="inherit"
-            onClick={() => handleViewChange("ExtrasView")}
-            sx={{
-              bgcolor:
-                currentView === "ExtrasView"
-                  ? "rgba(255,255,255,0.2)"
-                  : "transparent",
-            }}
-          >
-            Extras
-          </Button>
+            {/* Buttons to change between views */}
+            <Button
+              color="inherit"
+              onClick={() => handleViewChange("DriveView")}
+              sx={{
+                bgcolor:
+                  currentView === "DriveView"
+                    ? "rgba(255,255,255,0.2)"
+                    : "transparent",
+              }}
+            >
+              Drive
+            </Button>
+            <Button
+              color="inherit"
+              onClick={() => handleViewChange("ArmView")}
+              sx={{
+                bgcolor:
+                  currentView === "ArmView"
+                    ? "rgba(255,255,255,0.2)"
+                    : "transparent",
+              }}
+            >
+              Arm
+            </Button>
+            <Button
+              color="inherit"
+              onClick={() => handleViewChange("ScienceView")}
+              sx={{
+                bgcolor:
+                  currentView === "ScienceView"
+                    ? "rgba(255,255,255,0.2)"
+                    : "transparent",
+              }}
+            >
+              Science
+            </Button>
+            <Button
+              color="inherit"
+              onClick={() => handleViewChange("AutonomyView")}
+              sx={{
+                bgcolor:
+                  currentView === "AutonomyView"
+                    ? "rgba(255,255,255,0.2)"
+                    : "transparent",
+              }}
+            >
+              Autonomy
+            </Button>
+            <Button
+              color="inherit"
+              onClick={() => handleViewChange("ExtrasView")}
+              sx={{
+                bgcolor:
+                  currentView === "ExtrasView"
+                    ? "rgba(255,255,255,0.2)"
+                    : "transparent",
+              }}
+            >
+              Extras
+            </Button>
           </Box>
 
           {/* fill the space between the buttons and the connection status */}
@@ -171,7 +170,7 @@ export default function TopAppBar({
             <span>
               <Button
                 sx={{
-                  mr:2,
+                  mr: 2,
                   flexShrink: 0,
                   whiteSpace: "nowrap",
                 }}
@@ -239,6 +238,32 @@ export default function TopAppBar({
         }}
       >
         <List>
+          <Box sx={{ display: { xs: "block", lg: "none" } }}>
+            <ListItem>
+              <Typography sx={{ color: "black" }} variant="h6">
+                VIEWS
+              </Typography>
+            </ListItem>
+            <ListItem button onClick={() => handleViewChange("DriveView")}>
+              <Typography sx={{ color: "black" }}>Drive</Typography>
+            </ListItem>
+
+            <ListItem button onClick={() => handleViewChange("ArmView")}>
+              <Typography sx={{ color: "black" }}>Arm</Typography>
+            </ListItem>
+
+            <ListItem button onClick={() => handleViewChange("ScienceView")}>
+              <Typography sx={{ color: "black" }}>Science</Typography>
+            </ListItem>
+
+            <ListItem button onClick={() => handleViewChange("AutonomyView")}>
+              <Typography sx={{ color: "black" }}>Autonomy</Typography>
+            </ListItem>
+
+            <ListItem button onClick={() => handleViewChange("ExtrasView")}>
+              <Typography sx={{ color: "black" }}>Extras</Typography>
+            </ListItem>
+          </Box>
           <ListItem>
             <Typography sx={{ color: "black" }} variant="h6">
               SETTINGS

--- a/src/components/ui/TopAppBar.jsx
+++ b/src/components/ui/TopAppBar.jsx
@@ -12,7 +12,7 @@ import {
   Checkbox,
   Dialog,
   DialogTitle,
-  Tooltip
+  Tooltip,
 } from "@mui/material";
 import MenuIcon from "@mui/icons-material/Menu";
 import FullscreenIcon from "@mui/icons-material/Fullscreen";
@@ -22,7 +22,6 @@ import GamepadPanel from "../gamepad/Gamepad";
 import Metrics from "../metrics/metrics";
 import StateMachine from "../statemachine/statemachine";
 import { robotsocket, useRobotSocketStatus } from "../socket.io/socket";
-
 
 export default function TopAppBar({
   setCurrentView,
@@ -103,27 +102,63 @@ export default function TopAppBar({
           </Typography>
 
           {/* Buttons to change between views */}
-          <Button color="inherit" onClick={() => handleViewChange("DriveView")}>
+          <Button
+            color="inherit"
+            onClick={() => handleViewChange("DriveView")}
+            sx={{
+              bgcolor:
+                currentView === "DriveView"
+                  ? "rgba(255,255,255,0.2)"
+                  : "transparent",
+            }}
+          >
             Drive
           </Button>
-          <Button color="inherit" onClick={() => handleViewChange("ArmView")}>
+          <Button
+            color="inherit"
+            onClick={() => handleViewChange("ArmView")}
+            sx={{
+              bgcolor:
+                currentView === "ArmView"
+                  ? "rgba(255,255,255,0.2)"
+                  : "transparent",
+            }}
+          >
             Arm
           </Button>
           <Button
             color="inherit"
             onClick={() => handleViewChange("ScienceView")}
+            sx={{
+              bgcolor:
+                currentView === "ScienceView"
+                  ? "rgba(255,255,255,0.2)"
+                  : "transparent",
+            }}
           >
             Science
           </Button>
           <Button
             color="inherit"
             onClick={() => handleViewChange("AutonomyView")}
+            sx={{
+              bgcolor:
+                currentView === "AutonomyView"
+                  ? "rgba(255,255,255,0.2)"
+                  : "transparent",
+            }}
           >
             Autonomy
           </Button>
           <Button
             color="inherit"
             onClick={() => handleViewChange("ExtrasView")}
+            sx={{
+              bgcolor:
+                currentView === "ExtrasView"
+                  ? "rgba(255,255,255,0.2)"
+                  : "transparent",
+            }}
           >
             Extras
           </Button>
@@ -131,24 +166,24 @@ export default function TopAppBar({
           {/* fill the space between the buttons and the connection status */}
           <div style={{ flexGrow: 1 }} />
           <Tooltip disableFocusListener title="USE CAPS LOCK TO ARM">
-          <span>
-          <Button
-            style={{
-              marginRight: 20,
-            }}
-            variant="contained"
-            color="error"
-            loading={estopStatus == "LOADING"}
-            disabled={!capsLockActive || !isRobotConnected}
-            onClick={() => {
-              if (capsLockActive) {
-                initiateEstop();
-              }
-            }}
-          >
-            E-STOP
-          </Button>
-          </span>
+            <span>
+              <Button
+                style={{
+                  marginRight: 20,
+                }}
+                variant="contained"
+                color="error"
+                loading={estopStatus == "LOADING"}
+                disabled={!capsLockActive || !isRobotConnected}
+                onClick={() => {
+                  if (capsLockActive) {
+                    initiateEstop();
+                  }
+                }}
+              >
+                E-STOP
+              </Button>
+            </span>
           </Tooltip>
 
           <Dialog

--- a/src/components/ui/TopAppBar.jsx
+++ b/src/components/ui/TopAppBar.jsx
@@ -13,6 +13,7 @@ import {
   Dialog,
   DialogTitle,
   Tooltip,
+  Box
 } from "@mui/material";
 import MenuIcon from "@mui/icons-material/Menu";
 import FullscreenIcon from "@mui/icons-material/Fullscreen";
@@ -89,17 +90,17 @@ export default function TopAppBar({
           >
             <MenuIcon />
           </IconButton>
-          {/* sx: hide "Teleoperations" title on phones in portrait mode so menubar fits */}
           <Typography
             variant="h6"
             component="div"
             sx={{
-              display: { xs: "none", sm: "none", md: "block" },
               pr: 1, // add left padding to align with toolbar items
+              display: { xs: "none", md: "inline-flex" }
             }}
           >
             Teleoperations
           </Typography>
+          <Box sx={{ display: { xs: "none", lg: "inline-flex" } }}>
 
           {/* Buttons to change between views */}
           <Button
@@ -162,14 +163,17 @@ export default function TopAppBar({
           >
             Extras
           </Button>
+          </Box>
 
           {/* fill the space between the buttons and the connection status */}
           <div style={{ flexGrow: 1 }} />
           <Tooltip disableFocusListener title="USE CAPS LOCK TO ARM">
             <span>
               <Button
-                style={{
-                  marginRight: 20,
+                sx={{
+                  mr:2,
+                  flexShrink: 0,
+                  whiteSpace: "nowrap",
                 }}
                 variant="contained"
                 color="error"


### PR DESCRIPTION
Reimplementation of #125 with @emaeveky's code

<img width="566" height="416" alt="Screenshot 2026-04-03 at 12 22 21 PM" src="https://github.com/user-attachments/assets/3ad76ce8-7a4e-4e8c-b7ae-f238f5b58c83" />
<img width="1115" height="487" alt="Screenshot 2026-04-03 at 12 22 36 PM" src="https://github.com/user-attachments/assets/08c2f021-2fea-4e68-94f5-c1df1bcba679" />
