### PR TITLE
Metrics SSH improvements, CAN for mast, cameras only UI

### DIFF
--- a/base-pi/config.py
+++ b/base-pi/config.py
@@ -1,5 +1,5 @@
 silenceSSHErrors = False
 # how often should metrics be broadcast?
 # ALL ARE IN SECONDS
-AntennaPollingRate = 3
-RpiPollingRate = 3
+AntennaPollingRate = 2
+RpiPollingRate = 2

--- a/base-pi/metrics.py
+++ b/base-pi/metrics.py
@@ -48,44 +48,56 @@ async def cpuloop(sio):
 
 
 async def asyncsshloop(sio):
+    conn = None
+
     while True:
         if not username:
             await sio.emit('antennastats', {'status': "ERROR: NO SSH CREDS"})
+            await asyncio.sleep(1)
             continue
+
         try:
-            #print("Testing ssh...")
-            async with asyncio.timeout(config.AntennaPollingRate):
-                async with asyncssh.connect("192.168.1.20", username=username, password=password) as conn:
-                    try:
-                        #print("CONNECTED")
-                        res = await conn.run("mca-status | grep signal", check=False)
-                        dbm = res.stdout.strip()
-                        res = await conn.run("mca-status | grep wlanTxRate", check=False)
-                        txrate = res.stdout.strip()
-                        res = await conn.run("mca-status | grep wlanRxRate", check=False)
-                        rxrate = res.stdout.strip()
-                        # typical frequency is 924MHz with a channel width of 8, becoming 920-928MHz
-                        res = await conn.run("mca-status | grep centerFreq", check=False)
-                        freq = res.stdout.strip()  # 924
-                        res = await conn.run("mca-status | grep chanbw", check=False)
-                        freqwidth = res.stdout.strip()  # 8
-                        data = {
-                            'status': "GOOD",
-                            'dbm': dbm[7:],
-                            'txrate': txrate[11:],
-                            'rxrate': rxrate[11:],
-                            'freq': freq[11:],
-                            'freqwidth': freqwidth[7:]
-                        }
-                        await sio.emit('antennastats', data)
-                    except Exception as e:
-                        if (config.silenceSSHErrors == False):
-                            print("ERROR RETRIEVING SSH DATA!:", e)
+            # ensure connection (reuse if possible)
+            if conn is None :
+                conn = await asyncssh.connect(
+                    "192.168.1.20",
+                    username=username,
+                    password=password,
+                )
+
+            # single command to reduce round-trips
+            res = await asyncio.wait_for(
+                conn.run(
+                    "mca-status | egrep 'signal|wlanTxRate|wlanRxRate|centerFreq|chanbw'",
+                    check=False
+                ),
+                timeout=config.AntennaPollingRate * 2
+            )
+
+            lines = res.stdout.splitlines()
+            parsed = {k: v for k, v in (line.split('=') for line in lines if '=' in line)}
+
+            data = {
+                'status': "GOOD",
+                'dbm': parsed.get('signal', ''),
+                'txrate': parsed.get('wlanTxRate', ''),
+                'rxrate': parsed.get('wlanRxRate', ''),
+                'freq': parsed.get('centerFreq', ''),
+                'freqwidth': parsed.get('chanbw', '')
+            }
+
+            await sio.emit('antennastats', data)
+
         except Exception as e:
-            if(config.silenceSSHErrors == False):
-                print("SSH connection failed:" + str(e))
+            if not config.silenceSSHErrors:
+                print("SSH error:", e)
+
             await sio.emit('antennastats', {'status': "ERROR: OFFLINE"})
-        #print("Sleeping")
+
+            # reset connection and back off slightly
+            conn = None
+            await asyncio.sleep(2)
+
         await asyncio.sleep(config.AntennaPollingRate)
 
 
@@ -106,4 +118,3 @@ def register_metric_events(sio):
     async def pingCheck(sid):
         #unlike the others ping works better as a query and respond than otherwise
         return 1
-

--- a/base-pi/metrics.py
+++ b/base-pi/metrics.py
@@ -103,7 +103,6 @@ async def asyncsshloop(sio):
                 conn.close()
                 await conn.wait_closed()
                 conn = None
-            await asyncio.sleep(config.AntennaPollingRate)
 
         await asyncio.sleep(config.AntennaPollingRate)
 

--- a/base-pi/metrics.py
+++ b/base-pi/metrics.py
@@ -115,8 +115,8 @@ async def send_fake_antenna_stats(sio):
         data = {
             'status': "GOOD", # Reports good if link is successful
             'dbm': random.randint(-90, -30),             # signal strength
-            'txrate': round(random.uniform(1, 10), 2),  # Mbps
-            'rxrate': round(random.uniform(1, 10), 2),  # Mbps
+            'txrate': round(random.uniform(1, 10), 1),  # Mbps
+            'rxrate': round(random.uniform(1, 10), 1),  # Mbps
             'freq': random.choice([904, 914, 924]),   # MHz
             'freqwidth': random.choice([3, 5, 8, 20]),
             'noise': random.randint(-100, -70),          # dBm

--- a/base-pi/metrics.py
+++ b/base-pi/metrics.py
@@ -5,6 +5,7 @@ import os
 import asyncio
 import config # holds config values
 import psutil
+import random
 from pathlib import Path
 
 numClients = 0
@@ -68,7 +69,7 @@ async def asyncsshloop(sio):
             # single command to reduce round-trips
             async with asyncio.timeout(10):
                 res = await conn.run(
-                    "mca-status | grep -E 'signal|wlanTxRate|wlanRxRate|centerFreq|chanbw'",
+                    "mca-status | grep -E 'signal|wlanTxRate|wlanRxRate|centerFreq|chanbw|noise|wlanPollingCapacity'",
                     check=False
                 )
 
@@ -84,7 +85,9 @@ async def asyncsshloop(sio):
                 'txrate': parsed.get('wlanTxRate'),
                 'rxrate': parsed.get('wlanRxRate'),
                 'freq': parsed.get('centerFreq'),
-                'freqwidth': parsed.get('chanbw')
+                'freqwidth': parsed.get('chanbw'),
+                'noise': parsed.get('noise'),
+                "efficiency" : parsed.get('wlanPollingCapacity')
             }
 
             await sio.emit('antennastats', data)
@@ -104,6 +107,24 @@ async def asyncsshloop(sio):
 
         await asyncio.sleep(config.AntennaPollingRate)
 
+
+
+# function to generate and send fake data, pass in --offline flag to server to use
+async def send_fake_antenna_stats(sio):
+    while True:
+        data = {
+            'status': "GOOD", # Reports good if link is successful
+            'dbm': random.randint(-90, -30),             # signal strength
+            'txrate': round(random.uniform(1, 10), 2),  # Mbps
+            'rxrate': round(random.uniform(1, 10), 2),  # Mbps
+            'freq': random.choice([904, 914, 924]),   # MHz
+            'freqwidth': random.choice([3, 5, 8, 20]),
+            'noise': random.randint(-100, -70),          # dBm
+            'efficiency': round(random.uniform(0, 100), 2)  # %
+        }
+
+        await sio.emit('antennastats', data)
+        await asyncio.sleep(config.AntennaPollingRate)
 
 
 

--- a/base-pi/metrics.py
+++ b/base-pi/metrics.py
@@ -58,7 +58,7 @@ async def asyncsshloop(sio):
 
         try:
             # ensure connection (reuse if possible)
-            if conn is None :
+            if conn is None:
                 conn = await asyncssh.connect(
                     "192.168.1.20",
                     username=username,
@@ -66,24 +66,24 @@ async def asyncsshloop(sio):
                 )
 
             # single command to reduce round-trips
-            res = await asyncio.wait_for(
-                conn.run(
-                    "mca-status | egrep 'signal|wlanTxRate|wlanRxRate|centerFreq|chanbw'",
-                    check=False
-                ),
-                timeout=config.AntennaPollingRate * 2
+            res = await conn.run(
+                "mca-status | grep -E 'signal|wlanTxRate|wlanRxRate|centerFreq|chanbw'",
+                check=False
             )
 
-            lines = res.stdout.splitlines()
-            parsed = {k: v for k, v in (line.split('=') for line in lines if '=' in line)}
+            parsed = {}
+            for line in res.stdout.splitlines():
+                if '=' in line:
+                    k, v = line.split('=', 1)
+                    parsed[k.strip()] = v.strip()
 
             data = {
                 'status': "GOOD",
-                'dbm': parsed.get('signal', ''),
-                'txrate': parsed.get('wlanTxRate', ''),
-                'rxrate': parsed.get('wlanRxRate', ''),
-                'freq': parsed.get('centerFreq', ''),
-                'freqwidth': parsed.get('chanbw', '')
+                'dbm': parsed.get('signal'),
+                'txrate': parsed.get('wlanTxRate'),
+                'rxrate': parsed.get('wlanRxRate'),
+                'freq': parsed.get('centerFreq'),
+                'freqwidth': parsed.get('chanbw')
             }
 
             await sio.emit('antennastats', data)

--- a/base-pi/metrics.py
+++ b/base-pi/metrics.py
@@ -59,17 +59,18 @@ async def asyncsshloop(sio):
         try:
             # ensure connection (reuse if possible)
             if conn is None:
-                conn = await asyncssh.connect(
-                    "192.168.1.20",
-                    username=username,
-                    password=password,
-                )
-
+                async with asyncio.timeout(10):
+                    conn = await asyncssh.connect(
+                        "192.168.1.20",
+                        username=username,
+                        password=password,
+                    )
             # single command to reduce round-trips
-            res = await conn.run(
-                "mca-status | grep -E 'signal|wlanTxRate|wlanRxRate|centerFreq|chanbw'",
-                check=False
-            )
+            async with asyncio.timeout(10):
+                res = await conn.run(
+                    "mca-status | grep -E 'signal|wlanTxRate|wlanRxRate|centerFreq|chanbw'",
+                    check=False
+                )
 
             parsed = {}
             for line in res.stdout.splitlines():
@@ -95,8 +96,11 @@ async def asyncsshloop(sio):
             await sio.emit('antennastats', {'status': "ERROR: OFFLINE"})
 
             # reset connection and back off slightly
-            conn = None
-            await asyncio.sleep(2)
+            if conn is not None:
+                conn.close()
+                await conn.wait_closed()
+                conn = None
+            await asyncio.sleep(config.AntennaPollingRate)
 
         await asyncio.sleep(config.AntennaPollingRate)
 

--- a/base-pi/py_server.py
+++ b/base-pi/py_server.py
@@ -4,9 +4,16 @@ import metrics
 import asyncio
 import signal
 import sys
-from metrics import asyncsshloop, register_metric_events, cpuloop
+from metrics import asyncsshloop, register_metric_events, cpuloop, send_fake_antenna_stats
+import sys
 
 
+# run python 3 py_server.py --offline to send fake data instead for ssh
+offline = "--offline" in sys.argv
+if (offline):
+    print("Offline mode enabled, using mock data instead")
+else:
+    print("Online mode, SSH ready... ")
 
 
 
@@ -77,8 +84,11 @@ async def connect(sid,environ):
 
     # Start background loop once
     if not async_ssh_started:
-       async_ssh_started = True
-       sio.start_background_task(asyncsshloop,sio)
+        async_ssh_started = True
+        if offline:
+            sio.start_background_task(send_fake_antenna_stats,sio)
+        else:
+            sio.start_background_task(asyncsshloop,sio)
     if not cpu_started:
         cpu_started = True
         sio.start_background_task(cpuloop,sio)

--- a/base-pi/py_server.py
+++ b/base-pi/py_server.py
@@ -3,7 +3,6 @@ import uvicorn
 import metrics
 import asyncio
 import signal
-import sys
 from metrics import asyncsshloop, register_metric_events, cpuloop, send_fake_antenna_stats
 import sys
 

--- a/base-pi/run.sh
+++ b/base-pi/run.sh
@@ -1,2 +1,4 @@
 source .venv/bin/activate
-python3 ./py_server.py
+# "$@" passes in all arguments from script to the python server
+# ./run.sh --offline --> python3 ./py_server.py --offline
+python3 ./py_server.py "$@"

--- a/server/camera_pt.py
+++ b/server/camera_pt.py
@@ -6,14 +6,14 @@ import math
 
 def register_camera_pt_events(sio,serial_ports):
     print("registering...")
-    @sio.event
 
+    @sio.event
     async def mastCommands(sid,data):
         try:
             print("Camera Pan Commands X: " + str(data['xVel']) + " Y: " + str(data['yVel']))
             # frontend is from -90 to 90, but controls expects 0 to 180 so add 90
             panx_scaled = data['xVel'] + 90
-            pany_scaled = data['xVel'] + 90
+            pany_scaled = data['yVel'] + 90
             # convert into useable can format
             panx = panx_scaled.to_bytes(2, 'big', signed=True).hex()
             pany = pany_scaled.to_bytes(2, 'big', signed=True).hex()

--- a/server/camera_pt.py
+++ b/server/camera_pt.py
@@ -26,6 +26,7 @@ def register_camera_pt_events(sio,serial_ports):
 
         except Exception as e:
             # if you are testing on a computer without serial, set the bool true to help your console
+            print("Error sending Mast Pan Command!")
             if config.silenceSerialErrors == False:
                 print(f'Error in mastCommands: {e}')
 

--- a/server/camera_pt.py
+++ b/server/camera_pt.py
@@ -7,5 +7,27 @@ import math
 def register_camera_pt_events(sio,serial_ports):
     print("registering...")
     @sio.event
-    async def panCommands(sid,data):
-        print("Camera Pan Commands X: " + str(data['xVel']) + " Y: " + str(data['yVel']))
+
+    async def mastCommands(sid,data):
+        try:
+            print("Camera Pan Commands X: " + str(data['xVel']) + " Y: " + str(data['yVel']))
+            # frontend is from -90 to 90, but controls expects 0 to 180 so add 90
+            panx_scaled = data['xVel'] + 90
+            pany_scaled = data['xVel'] + 90
+            # convert into useable can format
+            panx = panx_scaled.to_bytes(2, 'big', signed=True).hex()
+            pany = pany_scaled.to_bytes(2, 'big', signed=True).hex()
+            # Mast CAN ID
+            MAST_CAN_ID= "300" # 0x300
+
+            can_msg = f't{MAST_CAN_ID}2{panx}{pany}\r'
+            await asyncio.to_thread(serial_ports["drive"].write, can_msg.encode())
+            print(f'[{sid}] Mast command sent: {can_msg}')
+
+        except Exception as e:
+            # if you are testing on a computer without serial, set the bool true to help your console
+            if config.silenceSerialErrors == False:
+                print(f'Error in mastCommands: {e}')
+
+
+

--- a/server/camera_pt.py
+++ b/server/camera_pt.py
@@ -14,9 +14,9 @@ def register_camera_pt_events(sio,serial_ports):
             # frontend is from -90 to 90, but controls expects 0 to 180 so add 90
             panx_scaled = data['xVel'] + 90
             pany_scaled = data['yVel'] + 90
-            # convert into useable can format
-            panx = panx_scaled.to_bytes(2, 'big', signed=True).hex()
-            pany = pany_scaled.to_bytes(2, 'big', signed=True).hex()
+            # uses 1 byte (8-bit) UNSIGNED = range of 0-255
+            panx = panx_scaled.to_bytes(1, 'big', signed=False).hex()
+            pany = pany_scaled.to_bytes(1, 'big', signed=False).hex()
             # Mast CAN ID
             MAST_CAN_ID= "300" # 0x300
 

--- a/src/components/cameras/CameraPane.jsx
+++ b/src/components/cameras/CameraPane.jsx
@@ -31,40 +31,10 @@ export default function CameraPane({ cameraValue, onCameraChange }){
     const cameras = [
       { value: "Standby", mediatype: "image", name: "Standby", url: "/mars.jpg" },
       {
-        value: "Mast Cam",
+        value: "Testing Camera",
         mediatype: "iframe",
-        name: "Mast Cam",
-        url: "http://192.168.1.114:8889/mast-720p/",
-      },
-      {
-        value: "Wheels Cam",
-        mediatype: "iframe",
-        name: "Wheels Cam",
-        url: "http://192.168.1.114:8889/wheels-720p/",
-      },
-      {
-        value: "Autonomy Cam",
-        mediatype: "iframe",
-        name: "Drive Cam",
-        url: "http://192.168.1.114:8889/vision-720p/",
-      },
-      {
-        value: "Arm 1",
-        mediatype: "iframe",
-        name: "Arm Base",
-        url: "http://192.168.1.114:8889/one-720p",
-      },
-      {
-        value: "Arm 2",
-        mediatype: "iframe",
-        name: "Arm Front",
-        url: "http://192.168.1.114:8889/two-720p/",
-      },
-      {
-        value: "Demo",
-        mediatype: "iframe",
-        name: "Demo",
-        url: "http://192.168.1.2:8889/masttesting/",
+        name: "Mast",
+        url: "http://192.168.1.2:8889/mast/",
       },
     ];
 

--- a/src/components/cameras/CameraPane.jsx
+++ b/src/components/cameras/CameraPane.jsx
@@ -31,7 +31,7 @@ export default function CameraPane({ cameraValue, onCameraChange }){
     const cameras = [
       { value: "Standby", mediatype: "image", name: "Standby", url: "/mars.jpg" },
       {
-        value: "Testing Camera",
+        value: "Mast Camera",
         mediatype: "iframe",
         name: "Mast",
         url: "http://192.168.1.2:8889/mast/",

--- a/src/components/gamepad/DriveWidget.jsx
+++ b/src/components/gamepad/DriveWidget.jsx
@@ -95,7 +95,7 @@ export default function DriveManualInput({}) {
       moduleConflicts: Number(moduleConflicts),
     });
 
-    robotsocket.emit("panCommands", {
+    robotsocket.emit("mastCommands", {
       xVel: panX,
       yVel: panY,
     });

--- a/src/components/metrics/metrics.jsx
+++ b/src/components/metrics/metrics.jsx
@@ -135,26 +135,25 @@ export default function Metrics({ openPane, setOpenPane }) {
               {antenna.status === "GOOD" ? (
                 <div>
                   <Typography sx={{ color: "black" }}>
-                    Signal Strength: {antenna.roverRSSI} dBm
+                    Strength: {antenna.roverRSSI} dBm
                   </Typography>
                   <Typography sx={{ color: "black" }}>
-                    Signal Noise: {antenna.noise} dBm
+                    Noise: {antenna.noise} dBm
                   </Typography>
                   <Typography sx={{ color: "black" }}>
                     Efficiency: {antenna.efficiency}%
                   </Typography>
                   <Typography sx={{ color: "black" }}>
-                    TX Speed: {antenna.txrate} Mbps
+                    TX & RX: {antenna.txrate}, {antenna.rxrate} Mbps
                   </Typography>
-                  <Typography sx={{ color: "black" }}>
-                    RX Speed: {antenna.rxrate} Mbps
-                  </Typography>
+                  <hr className="border-t border-gray-300 my-2 w-1/2 mx-auto" />
                   <Typography sx={{ color: "black" }}>
                     Frequency: {antenna.freq} MHz
                   </Typography>
                   <Typography sx={{ color: "black" }}>
                     Frequency Width: {antenna.freqw} MHz
                   </Typography>
+                  
                 </div>
               ) : (
                 <Typography sx={{ color: "black" }}>

--- a/src/components/metrics/metrics.jsx
+++ b/src/components/metrics/metrics.jsx
@@ -14,6 +14,8 @@ export default function Metrics({ openPane, setOpenPane }) {
     roverRSSI: null,
     txrate: null,
     rxrate: null,
+    noise: null,
+    efficiency : null,
     freq: null,
     freqw: null,
   });
@@ -39,6 +41,8 @@ export default function Metrics({ openPane, setOpenPane }) {
         roverRSSI: data.dbm,
         txrate: data.txrate,
         rxrate: data.rxrate,
+        noise: data.noise,
+        efficiency : data.efficiency,
         freq: data.freq,
         freqw: data.freqwidth,
       });
@@ -132,6 +136,12 @@ export default function Metrics({ openPane, setOpenPane }) {
                 <div>
                   <Typography sx={{ color: "black" }}>
                     Signal Strength: {antenna.roverRSSI} dBm
+                  </Typography>
+                  <Typography sx={{ color: "black" }}>
+                    Signal Noise: {antenna.noise} dBm
+                  </Typography>
+                  <Typography sx={{ color: "black" }}>
+                    Efficiency: {antenna.efficiency}%
                   </Typography>
                   <Typography sx={{ color: "black" }}>
                     TX Speed: {antenna.txrate} Mbps

--- a/src/components/ui/TopAppBar.jsx
+++ b/src/components/ui/TopAppBar.jsx
@@ -14,7 +14,9 @@ import {
   DialogTitle,
   Tooltip,
   ListItemButton,
-  Box
+  Box,
+  ToggleButtonGroup,
+  ToggleButton
 } from "@mui/material";
 import MenuIcon from "@mui/icons-material/Menu";
 import FullscreenIcon from "@mui/icons-material/Fullscreen";
@@ -28,10 +30,8 @@ import { robotsocket, useRobotSocketStatus } from "../socket.io/socket";
 export default function TopAppBar({
   setCurrentView,
   currentView,
-  camsVisibility,
-  setcamsVisibility,
-  uiVisibility, 
-  setuiVisibility
+  selectedElements, 
+  setselectedElements
 }) {
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [openPane, setOpenPane] = useState("None");
@@ -71,6 +71,10 @@ export default function TopAppBar({
       window.removeEventListener("keyup", updateCapsState);
     };
   }, []);
+
+  const changeElements = (event, newAlignment) => {
+    setselectedElements(newAlignment);
+  };
 
   return (
     <>
@@ -312,30 +316,20 @@ export default function TopAppBar({
           </Box>
           <ListItem>
             <Typography sx={{ color: "black" }} variant="h6">
-              SETTINGS
+              SPLIT SCREEN
             </Typography>
           </ListItem>
           <ListItem>
-            <FormControlLabel
-              control={
-                <Checkbox
-                  checked={camsVisibility}
-                  onChange={(e) => setcamsVisibility(e.target.checked)}
-                />
-              }
-              label="Show Cameras"
-            />
-          </ListItem>
-                    <ListItem>
-            <FormControlLabel
-              control={
-                <Checkbox
-                  checked={uiVisibility}
-                  onChange={(e) => setuiVisibility(e.target.checked)}
-                />
-              }
-              label="Show UI"
-            />
+            <ToggleButtonGroup
+              color="primary"
+              value={selectedElements}
+              exclusive
+              onChange={changeElements}
+            >
+              <ToggleButton value="ui">UI</ToggleButton>
+              <ToggleButton value="both">BOTH</ToggleButton>
+              <ToggleButton value="cameras">CAMS</ToggleButton>
+            </ToggleButtonGroup>
           </ListItem>
         </List>
       </Drawer>

--- a/src/components/ui/TopAppBar.jsx
+++ b/src/components/ui/TopAppBar.jsx
@@ -8,8 +8,6 @@ import {
   ListItem,
   Typography,
   IconButton,
-  FormControlLabel,
-  Checkbox,
   Dialog,
   DialogTitle,
   Tooltip,
@@ -31,7 +29,7 @@ export default function TopAppBar({
   setCurrentView,
   currentView,
   selectedElements, 
-  setselectedElements
+  setSelectedElements
 }) {
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [openPane, setOpenPane] = useState("None");
@@ -73,7 +71,7 @@ export default function TopAppBar({
   }, []);
 
   const changeElements = (event, newAlignment) => {
-    setselectedElements(newAlignment);
+    setSelectedElements(newAlignment);
   };
 
   return (

--- a/src/components/ui/TopAppBar.jsx
+++ b/src/components/ui/TopAppBar.jsx
@@ -71,7 +71,9 @@ export default function TopAppBar({
   }, []);
 
   const changeElements = (event, newAlignment) => {
+    if(newAlignment !== null){
     setSelectedElements(newAlignment);
+    }
   };
 
   return (

--- a/src/components/ui/TopAppBar.jsx
+++ b/src/components/ui/TopAppBar.jsx
@@ -30,6 +30,8 @@ export default function TopAppBar({
   currentView,
   camsVisibility,
   setcamsVisibility,
+  uiVisibility, 
+  setuiVisibility
 }) {
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [openPane, setOpenPane] = useState("None");
@@ -322,6 +324,17 @@ export default function TopAppBar({
                 />
               }
               label="Show Cameras"
+            />
+          </ListItem>
+                    <ListItem>
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={uiVisibility}
+                  onChange={(e) => setuiVisibility(e.target.checked)}
+                />
+              }
+              label="Show UI"
             />
           </ListItem>
         </List>

--- a/src/views/App.jsx
+++ b/src/views/App.jsx
@@ -64,7 +64,7 @@ function App() {
     panSpeed: 30,
   });
 
-  const [selectedElements, setselectedElements] = useState("both");
+  const [selectedElements, setSelectedElements] = useState("both");
 
   // Select which view we want to display
   function renderView() {
@@ -140,7 +140,7 @@ function App() {
                   currentView={currentView}
                   setCurrentView={setCurrentView}
                   selectedElements={selectedElements}
-                  setselectedElements={setselectedElements}
+                  setSelectedElements={setSelectedElements}
                   addSnackbarMessage={addSnackbarMessage}
                 />
 

--- a/src/views/App.jsx
+++ b/src/views/App.jsx
@@ -64,46 +64,41 @@ function App() {
     panSpeed: 30,
   });
 
-  const [camsVisibility, setcamsVisibility] = useState(true);
-  const [uiVisibility, setuiVisibility] = useState(true);
+  const [selectedElements, setselectedElements] = useState("both");
 
   // Select which view we want to display
   function renderView() {
     switch (currentView) {
       case "ArmView":
         return (
-          <SplitView CurrentView={<ArmView />} showCameras={camsVisibility}  showUI = {uiVisibility}/>
+          <SplitView CurrentView={<ArmView />} selectedElements={selectedElements}/>
         );
       case "DriveView":
         return (
           <SplitView
             CurrentView={<DriveComponents />}
-            showCameras={camsVisibility}
-            showUI = {uiVisibility}
+            selectedElements={selectedElements}
           />
         );
       case "ExtrasView":
         return (
           <SplitView
             CurrentView={<ExtrasView />}
-            showCameras={camsVisibility}
-            showUI = {uiVisibility}
+            selectedElements={selectedElements}
           />
         );
       case "ScienceView":
         return (
           <SplitView
             CurrentView={<ScienceView />}
-            showCameras={camsVisibility}
-            showUI = {uiVisibility}
+            selectedElements={selectedElements}
           />
         );
       case "AutonomyView":
         return (
           <SplitView
             CurrentView={<AutonomyView />}
-            showCameras={camsVisibility}
-            showUI = {uiVisibility}
+            selectedElements={selectedElements}
           />
         );
       default:
@@ -144,10 +139,8 @@ function App() {
                 <TopAppBar
                   currentView={currentView}
                   setCurrentView={setCurrentView}
-                  camsVisibility={camsVisibility}
-                  setcamsVisibility={setcamsVisibility}
-                  uiVisibility = {uiVisibility}
-                  setuiVisibility = {setuiVisibility}
+                  selectedElements={selectedElements}
+                  setselectedElements={setselectedElements}
                   addSnackbarMessage={addSnackbarMessage}
                 />
 

--- a/src/views/App.jsx
+++ b/src/views/App.jsx
@@ -65,19 +65,21 @@ function App() {
   });
 
   const [camsVisibility, setcamsVisibility] = useState(true);
+  const [uiVisibility, setuiVisibility] = useState(true);
 
   // Select which view we want to display
   function renderView() {
     switch (currentView) {
       case "ArmView":
         return (
-          <SplitView CurrentView={<ArmView />} showCameras={camsVisibility} />
+          <SplitView CurrentView={<ArmView />} showCameras={camsVisibility}  showUI = {uiVisibility}/>
         );
       case "DriveView":
         return (
           <SplitView
             CurrentView={<DriveComponents />}
             showCameras={camsVisibility}
+            showUI = {uiVisibility}
           />
         );
       case "ExtrasView":
@@ -85,6 +87,7 @@ function App() {
           <SplitView
             CurrentView={<ExtrasView />}
             showCameras={camsVisibility}
+            showUI = {uiVisibility}
           />
         );
       case "ScienceView":
@@ -92,6 +95,7 @@ function App() {
           <SplitView
             CurrentView={<ScienceView />}
             showCameras={camsVisibility}
+            showUI = {uiVisibility}
           />
         );
       case "AutonomyView":
@@ -99,6 +103,7 @@ function App() {
           <SplitView
             CurrentView={<AutonomyView />}
             showCameras={camsVisibility}
+            showUI = {uiVisibility}
           />
         );
       default:
@@ -141,6 +146,8 @@ function App() {
                   setCurrentView={setCurrentView}
                   camsVisibility={camsVisibility}
                   setcamsVisibility={setcamsVisibility}
+                  uiVisibility = {uiVisibility}
+                  setuiVisibility = {setuiVisibility}
                   addSnackbarMessage={addSnackbarMessage}
                 />
 

--- a/src/views/SplitView.jsx
+++ b/src/views/SplitView.jsx
@@ -70,11 +70,7 @@ export default function DriveView({ CurrentView, selectedElements }) {
     window.addEventListener("pointerup", onPointerUp);
   }, []);
 
-  const effectiveLeftPct = !(
-    selectedElements == "cams" || selectedElements == "both"
-  )
-    ? 100
-    : leftPct;
+    const effectiveLeftPct = (selectedElements == "ui" ) ? 100 : leftPct;
 
   useEffect(() => {
     if (!hydrated) return;

--- a/src/views/SplitView.jsx
+++ b/src/views/SplitView.jsx
@@ -109,7 +109,7 @@ export default function DriveView({ CurrentView, selectedElements }) {
   const getGridColumns = (cameraNum) => {
     if (cameraNum === 1) return "1fr";
     if (cameraNum === 4) return "repeat(2,1fr)";
-    return "repeat(auto-fit, minmax(300px, 1fr))";
+    return "repeat(auto-fit, minmax(250px, 1fr))";
   };
 
   return (

--- a/src/views/SplitView.jsx
+++ b/src/views/SplitView.jsx
@@ -13,7 +13,7 @@ const DEFAULT_CAMERA = "Standby";
 const DEFAULT_CAMERA_NUM = 2;
 const STORAGE_KEY = "missionControl.cameraLayout";
 
-export default function DriveView({ CurrentView, showCameras }) {
+export default function DriveView({ CurrentView, showCameras, showUI }) {
   const containerRef = useRef(null);
   const [leftPct, setLeftPct] = useState(65);
   const [cameraNum, setCameraNum] = useState(DEFAULT_CAMERA_NUM);
@@ -112,6 +112,7 @@ export default function DriveView({ CurrentView, showCameras }) {
       className="flex flex-1 h-full min-h-0"
       style={{ userSelect: "none" }}
     >
+      {showUI && (
       <div
         className="flex flex-col gap-2 p-2 bg-gray-100 min-h-0"
         style={{ flex: `0 0 ${effectiveLeftPct}%` }}
@@ -123,8 +124,9 @@ export default function DriveView({ CurrentView, showCameras }) {
           <CurrentView />
         ) : null}
       </div>
+      )}
 
-      {showCameras && (
+      {(showCameras && showUI) && (
         <div
           role="separator"
           aria-orientation="vertical"
@@ -170,6 +172,7 @@ export default function DriveView({ CurrentView, showCameras }) {
           >
             <MenuItem value={1}>1 Camera</MenuItem>
             <MenuItem value={2}>2 Cameras</MenuItem>
+            <MenuItem value={3}>3 Cameras</MenuItem>
             <MenuItem value={4}>4 Cameras</MenuItem>
           </Select>
         </FormControl>
@@ -183,6 +186,7 @@ export default function DriveView({ CurrentView, showCameras }) {
                   gridTemplateColumns: "repeat(2,1fr)",
                   gap: "6px",
                 }
+            
           }
           sx={cameraNum >= 3 ? { minWidth: 500 } : {}}
         >

--- a/src/views/SplitView.jsx
+++ b/src/views/SplitView.jsx
@@ -13,7 +13,7 @@ const DEFAULT_CAMERA = "Standby";
 const DEFAULT_CAMERA_NUM = 2;
 const STORAGE_KEY = "missionControl.cameraLayout";
 
-export default function DriveView({ CurrentView, showCameras, showUI }) {
+export default function DriveView({ CurrentView, selectedElements }) {
   const containerRef = useRef(null);
   const [leftPct, setLeftPct] = useState(65);
   const [cameraNum, setCameraNum] = useState(DEFAULT_CAMERA_NUM);
@@ -70,7 +70,7 @@ export default function DriveView({ CurrentView, showCameras, showUI }) {
     window.addEventListener("pointerup", onPointerUp);
   }, []);
 
-  const effectiveLeftPct = !showCameras ? 100 : leftPct;
+  const effectiveLeftPct = !(selectedElements== "cams" || selectedElements == "both") ? 100 : leftPct;
 
   useEffect(() => {
     if (!hydrated) return;
@@ -112,7 +112,7 @@ export default function DriveView({ CurrentView, showCameras, showUI }) {
       className="flex flex-1 h-full min-h-0"
       style={{ userSelect: "none" }}
     >
-      {showUI && (
+      {(selectedElements== "ui" || selectedElements == "both") && (
       <div
         className="flex flex-col gap-2 p-2 bg-gray-100 min-h-0"
         style={{ flex: `0 0 ${effectiveLeftPct}%` }}
@@ -126,7 +126,7 @@ export default function DriveView({ CurrentView, showCameras, showUI }) {
       </div>
       )}
 
-      {(showCameras && showUI) && (
+      {(selectedElements == "both") && (
         <div
           role="separator"
           aria-orientation="vertical"
@@ -147,7 +147,7 @@ export default function DriveView({ CurrentView, showCameras, showUI }) {
       <div
         className="flex-1 flex flex-col p-2 min-h-0"
         style={{
-          display: !showCameras ? "none" : "flex",
+          display: (selectedElements== "ui") ? "none" : "flex",
         }}
       >
         <FormControl
@@ -201,7 +201,7 @@ export default function DriveView({ CurrentView, showCameras, showUI }) {
         </div>
       </div>
 
-      {!showCameras && (
+      {(selectedElements== "ui") && (
         <div
           className="absolute cursor-pointer"
           style={{ background: "transparent" }}

--- a/src/views/SplitView.jsx
+++ b/src/views/SplitView.jsx
@@ -70,7 +70,11 @@ export default function DriveView({ CurrentView, selectedElements }) {
     window.addEventListener("pointerup", onPointerUp);
   }, []);
 
-  const effectiveLeftPct = !(selectedElements== "cams" || selectedElements == "both") ? 100 : leftPct;
+  const effectiveLeftPct = !(
+    selectedElements == "cams" || selectedElements == "both"
+  )
+    ? 100
+    : leftPct;
 
   useEffect(() => {
     if (!hydrated) return;
@@ -106,27 +110,33 @@ export default function DriveView({ CurrentView, selectedElements }) {
     });
   };
 
+  const getGridColumns = (cameraNum) => {
+    if (cameraNum === 1) return "1fr";
+    if (cameraNum === 4) return "repeat(2,1fr)";
+    return "repeat(auto-fit, minmax(300px, 1fr))";
+  };
+
   return (
     <div
       ref={containerRef}
       className="flex flex-1 h-full min-h-0"
       style={{ userSelect: "none" }}
     >
-      {(selectedElements== "ui" || selectedElements == "both") && (
-      <div
-        className="flex flex-col gap-2 p-2 bg-gray-100 min-h-0"
-        style={{ flex: `0 0 ${effectiveLeftPct}%` }}
-      >
-        {/* embed the current view */}
-        {isValidElement(CurrentView) ? (
-          CurrentView
-        ) : typeof CurrentView === "function" ? (
-          <CurrentView />
-        ) : null}
-      </div>
+      {(selectedElements == "ui" || selectedElements == "both") && (
+        <div
+          className="flex flex-col gap-2 p-2 bg-gray-100 min-h-0"
+          style={{ flex: `0 0 ${effectiveLeftPct}%` }}
+        >
+          {/* embed the current view */}
+          {isValidElement(CurrentView) ? (
+            CurrentView
+          ) : typeof CurrentView === "function" ? (
+            <CurrentView />
+          ) : null}
+        </div>
       )}
 
-      {(selectedElements == "both") && (
+      {selectedElements == "both" && (
         <div
           role="separator"
           aria-orientation="vertical"
@@ -147,7 +157,7 @@ export default function DriveView({ CurrentView, selectedElements }) {
       <div
         className="flex-1 flex flex-col p-2 min-h-0"
         style={{
-          display: (selectedElements== "ui") ? "none" : "flex",
+          display: selectedElements == "ui" ? "none" : "flex",
         }}
       >
         <FormControl
@@ -178,17 +188,12 @@ export default function DriveView({ CurrentView, selectedElements }) {
         </FormControl>
         <div
           className="flex-1 min-h-0 overflow-auto"
-          style={
-            cameraNum <= 3
-              ? { display: "flex", flexDirection: "column", gap: "6px" }
-              : {
-                  display: "grid",
-                  gridTemplateColumns: "repeat(2,1fr)",
-                  gap: "6px",
-                }
-            
-          }
-          sx={cameraNum >= 3 ? { minWidth: 500 } : {}}
+          style={{
+            display: "grid",
+            gridTemplateColumns: getGridColumns(cameraNum),
+            gap: "6px",
+            minWidth: cameraNum >= 3 ? 500 : undefined,
+          }}
         >
           {[...Array(cameraNum)].map((_, index) => (
             <div key={index} className="flex w-full h-full min-h-0">
@@ -201,7 +206,7 @@ export default function DriveView({ CurrentView, selectedElements }) {
         </div>
       </div>
 
-      {(selectedElements== "ui") && (
+      {selectedElements == "ui" && (
         <div
           className="absolute cursor-pointer"
           style={{ background: "transparent" }}


### PR DESCRIPTION
- SSH antenna metrics are more reliable and functional
- Draft CAN command for mast
- New picker allowing for only cameras, ui, or both
- New scaling for UI so cameras pane better scales to large screens
- New metrics display
- Base pi server --offline flag to use mock data, will passthrough with ./run.sh script
<img width="593" height="413" alt="Screenshot 2026-04-04 at 5 53 20 PM" src="https://github.com/user-attachments/assets/af59d69e-d153-4f81-ada2-bb99511bda0e" />
<img width="264" height="243" alt="image" src="https://github.com/user-attachments/assets/82852e75-55ca-4f56-8748-040ac77083f6" />

