### PR TITLE
Add UART feasibility path for drive communication

### DIFF
--- a/server/drive_uart.py
+++ b/server/drive_uart.py
@@ -1,0 +1,169 @@
+import asyncio
+
+DRIVE_MSG_ID = {
+    "SET_CHASSIS_VELOCITIES": 0x40,
+    "HEARTBEAT": 0x41,
+    "HOMING_SEQUENCE": 0x42,
+    "GET_ESTIMATED_VELOCITIES": 0x43,
+    "GET_OFFSET": 0x44,
+    "CONFIG": 0x5F,
+}
+
+DRIVE_REPLY_ID = {
+    "SET_VELOCITIES_RESPONSE": 0x60,
+    "HEARTBEAT_REPLY": 0x61,
+    "HOMING_SEQUENCE_RESPONSE": 0x62,
+    "RETURN_ESTIMATED_CHASSIS_VELOCITIES": 0x63,
+    "RETURN_OFFSET": 0x64,
+    "CONFIG_ACK": 0x7F,
+}
+
+
+def build_set_chassis_velocities_payload(x_vel, y_vel, rot_vel, module_conflicts):
+    # 16 bit signed integer correlating to the velocity in 2^12x meters/sec
+    x_vel_scaled = int(x_vel * (2 ** 12))
+    y_vel_scaled = int(y_vel * (2 ** 12))
+
+    # 16 bit signed integer correlating to the clockwise rotational velocity in 2^6x degrees/sec
+    rot_vel_scaled = int(rot_vel * (2 ** 6))
+    mod_conf_scaled = int(module_conflicts)
+
+    # convert each field into bytes and combine into one payload
+    payload = (
+        x_vel_scaled.to_bytes(2, "big", signed=True) +
+        y_vel_scaled.to_bytes(2, "big", signed=True) +
+        rot_vel_scaled.to_bytes(2, "big", signed=True) +
+        mod_conf_scaled.to_bytes(1, "big", signed=False)
+    )
+
+    return payload
+
+
+# =================== Client Drive Event Handlers ====================
+
+def register_drive_events(sio, serial_ports):
+    @sio.event
+    async def driveCommands(sid, data):
+        try:
+            # make sure drive UART is connected first
+            if serial_ports["drive"] is None:
+                print("Drive UART not connected")
+                return
+
+            payload = build_set_chassis_velocities_payload(
+                data["xVel"],
+                data["yVel"],
+                data["rotVel"],
+                data["moduleConflicts"],
+            )
+
+            # send_packet is blocking, run it in a thread
+            await asyncio.to_thread(
+                serial_ports["drive"].send_packet,
+                DRIVE_MSG_ID["SET_CHASSIS_VELOCITIES"],
+                payload,
+            )
+            print(f'[{sid}] Drive UART command sent')
+        except Exception as e:
+            print(f'Error in driveCommands: {e}')
+
+    @sio.event
+    async def driveHoming(sid):
+        try:
+            # make sure drive UART is connected first
+            if serial_ports["drive"] is None:
+                print("Drive UART not connected")
+                return
+
+            await asyncio.to_thread(
+                serial_ports["drive"].send_packet,
+                DRIVE_MSG_ID["HOMING_SEQUENCE"],
+                b""
+            )
+            print(f'[{sid}] Homing initiated')
+        except Exception as e:
+            print(f'Error in driveHoming: {e}')
+
+
+async def parse_drive_packet(packet):
+    try:
+        msg_id, payload = packet
+
+        if msg_id == DRIVE_REPLY_ID["HEARTBEAT_REPLY"]:
+            print("Heartbeat Reply")
+
+        elif msg_id == DRIVE_REPLY_ID["HOMING_SEQUENCE_RESPONSE"]:
+            print("Homing Reply")
+
+        elif msg_id == DRIVE_REPLY_ID["RETURN_ESTIMATED_CHASSIS_VELOCITIES"]:
+            if len(payload) != 6:
+                print("Bad estimated velocity payload length")
+                return
+
+            x_vel = int.from_bytes(payload[0:2], "big", signed=True)
+            y_vel = int.from_bytes(payload[2:4], "big", signed=True)
+            rot_vel = int.from_bytes(payload[4:6], "big", signed=True)
+
+            print(f"est x vel: {x_vel} \nest y vel: {y_vel} \nest rot vel {rot_vel}")
+
+        elif msg_id == DRIVE_REPLY_ID["SET_VELOCITIES_RESPONSE"]:
+            if len(payload) != 7:
+                print("Bad set velocities response payload length")
+                return
+
+            x_vel = int.from_bytes(payload[0:2], "big", signed=True)
+            y_vel = int.from_bytes(payload[2:4], "big", signed=True)
+            rot_vel = int.from_bytes(payload[4:6], "big", signed=True)
+            transition_type = payload[6]
+
+            print(
+                f"\nx vel: {x_vel} "
+                f"\ny vel: {y_vel} "
+                f"\nrot vel {rot_vel} "
+                f"\ntransition type: {transition_type}"
+            )
+
+        elif msg_id == DRIVE_REPLY_ID["RETURN_OFFSET"]:
+            if len(payload) != 3:
+                print("Bad return offset payload length")
+                return
+
+            # current UART version assumes 2-byte angle offset + 1-byte module position
+            angle_offset = int.from_bytes(payload[0:2], "big", signed=True)
+            module_position = payload[2]
+            print(f"angle offset: {angle_offset} \nmodule position: {module_position}")
+
+    except Exception as e:
+        print(f'Error parsing drive UART packet: {e}')
+
+
+async def read_drive_uart_loop(serial_ports):
+    try:
+        while True:
+            # read_packet is blocking so run it in a thread
+            drive = serial_ports["drive"]
+            if drive is not None:
+                packet = await asyncio.to_thread(drive.read_packet)
+                if packet:
+                    await parse_drive_packet(packet)
+            await asyncio.sleep(0.01)
+    except Exception as e:
+        print(f'Drive UART task error: {e}')
+
+
+# send heartbeat once in a while so drive can confirm MC is still alive
+async def send_drive_heartbeat(serial_ports):
+    try:
+        while True:
+            drive = serial_ports["drive"]
+            if drive is not None:
+                await asyncio.to_thread(
+                    drive.send_packet,
+                    DRIVE_MSG_ID["HEARTBEAT"],
+                    b""
+                )
+                print('Sent drive heartbeat')
+            await asyncio.sleep(5)
+    except Exception as e:
+        print(f'Drive heartbeat error: {e}')
+        

--- a/server/py_server.py
+++ b/server/py_server.py
@@ -7,10 +7,18 @@ import asyncio
 import signal
 import sys
 from metrics import cpuloop, register_metric_events
-from drive import read_drive_can_loop, send_drive_status_request, register_drive_events
+from drive import read_drive_can_loop, send_drive_status_request
+from uart_drive_serial import UartDriveSerial
+from drive_uart import read_drive_uart_loop, send_drive_heartbeat, register_drive_events
 from arm import read_arm_can_loop, request_arm_position_loop, register_arm_events
 from camera_pt import register_camera_pt_events
 from gps import ZEDF9P, GPS_Data, GNRMC, read_gps_data, send_fake_gps_data
+
+
+# Toggle drive communication transport for testing / fallback
+# True = UART drive path
+# False = original CAN drive path
+USE_UART_DRIVE = True
 
 # run python 3 py_server.py --offline to send fake data instead for ssh
 offline = "--offline" in sys.argv
@@ -136,9 +144,15 @@ async def connectDrive(sid,data):
         return("ERROR")
     print("Connecting to " + str(data))
     try:
-        serial_ports["drive"] = CanSerial(data)
+        # Use UART as a backup / alternative to CAN for drive communication
+        if USE_UART_DRIVE:
+            serial_ports["drive"] = UartDriveSerial(data)
+            print("Drive UART connected.")
+        else:
+            serial_ports["drive"] = CanSerial(data)
+            print("Drive CAN connected.")
+
         serial_ports["driveId"] = data
-        print("Drive connected.")
         return("OK")
     except Exception as e:
         print("FAILURE TO CONNECT DRIVE: " + str(e))
@@ -295,6 +309,7 @@ async def E_STOP(sid):
 # Background task guard
 can_error_message_started = False
 drive_task_started = False
+drive_heartbeat_started = False
 arm_task_started = False
 gps_task_started = False
 arm_position_task_started = False
@@ -314,6 +329,7 @@ async def connect(sid,environ):
     """On first client connect, start background CAN read loop."""
     global can_error_message_started
     global drive_task_started
+    global drive_heartbeat_started
     global arm_task_started
     global gps_task_started
     global async_ssh_started
@@ -329,8 +345,12 @@ async def connect(sid,environ):
 
     # Start background CAN loop once
     if not drive_task_started:
+        # Start either UART or CAN drive loop depending on selected transport
         drive_task_started = True
-        sio.start_background_task(read_drive_can_loop,serial_ports)
+        if USE_UART_DRIVE:
+            sio.start_background_task(read_drive_uart_loop, serial_ports)
+        else:
+            sio.start_background_task(read_drive_can_loop, serial_ports)
     if not arm_task_started:
         arm_task_started = True
         sio.start_background_task(read_arm_can_loop, serial_ports, sio)
@@ -343,9 +363,15 @@ async def connect(sid,environ):
             sio.start_background_task(send_fake_gps_data, sio)
         else:
             sio.start_background_task(read_gps_data, serial_ports, sio)
-    if not can_error_message_started:
-        can_error_message_started = True
-        sio.start_background_task(send_drive_status_request, serial_ports)
+    # UART drive path uses heartbeat instead of CANUSB status polling
+    if USE_UART_DRIVE:
+        if not drive_heartbeat_started:
+            drive_heartbeat_started = True
+            sio.start_background_task(send_drive_heartbeat, serial_ports)
+    else:
+        if not can_error_message_started:
+            can_error_message_started = True
+            sio.start_background_task(send_drive_status_request, serial_ports)
     if not async_ssh_started:
        async_ssh_started = True
        #sio.start_background_task(asyncsshloop,sio)

--- a/server/uart_drive_serial.py
+++ b/server/uart_drive_serial.py
@@ -1,0 +1,36 @@
+import serial
+
+# UART serial wrapper for drive communication
+class UartDriveSerial:
+    def __init__(self, port, baudrate=115200):
+        # open UART serial port
+        self.ser = serial.Serial(port, baudrate=baudrate, timeout=0.1)
+
+    def close(self):
+        # close UART serial port
+        self.ser.close()
+
+    def send_packet(self, msg_id, payload=b""):
+        # packet format for now:
+        # [msg_id][length][payload]
+        length = len(payload)
+        packet = bytes([msg_id, length]) + payload
+        print(f"TX: id={msg_id:#04x}, len={length}, payload={payload.hex()}")
+        self.ser.write(packet)
+
+    def read_packet(self):
+        # read first 2 bytes as [msg_id][length]
+        header = self.ser.read(2)
+        if len(header) < 2:
+            return None
+
+        msg_id = header[0]
+        length = header[1]
+
+        # then read the payload based on the packet length
+        payload = self.ser.read(length)
+        if len(payload) < length:
+            return None
+
+        return msg_id, payload
+    


### PR DESCRIPTION
## Summary
This PR adds a UART-based testing/feasibility path for drive communication as a backup alternative to the current CAN-based approach.

## Changes
- Added `uart_drive_serial.py` for UART packet send/read
- Added `drive_uart.py` for UART drive communication logic
- Updated `py_server.py` to support switching between CAN and UART drive paths with `USE_UART_DRIVE`
- Added UART heartbeat/read loop support

## Notes
- Drive payload format and IDs currently follow the [CAN Frames doc](https://docs.google.com/document/d/1QEvIs_GuIbW3S0wdR7ejucwhje3RqZTHkSPOGHXm22g/edit?tab=t.5a9becpmyoov)
- UART framing is currently implemented as:
  [msg_id][length][payload]
- `RETURN_OFFSET` currently follows the table definition (length 3) from the CAN Frames doc and may need later firmware clarification