### PR TITLE
CAN/UART flag shown on frontend

### DIFF
--- a/server/py_server.py
+++ b/server/py_server.py
@@ -115,6 +115,10 @@ print("Preparing for CAN...")
 # =================== CAN connections ===================
 @sio.event
 async def getCanInfo(sid):
+    uart_str = "CAN"
+    if USE_UART_DRIVE:
+        uart_str = "UART"
+
     # can ids for web ui
     canIds_arr = []
     for port in list_ports.comports():
@@ -130,6 +134,7 @@ async def getCanInfo(sid):
     'armId' : serial_ports["armId"],
     'scienceId' : serial_ports["scienceId"],
     'gpsId' : serial_ports["gpsId"],
+    "uartMode" : uart_str,
     }
     return data
 

--- a/src/components/socket.io/PeripheralManager.jsx
+++ b/src/components/socket.io/PeripheralManager.jsx
@@ -9,17 +9,17 @@ import FormControl from "@mui/material/FormControl";
 import Select from "@mui/material/Select";
 import ElectricalServicesIcon from "@mui/icons-material/ElectricalServices";
 import EjectIcon from "@mui/icons-material/Eject";
-import { useSnackbar } from 'notistack';
+import { useSnackbar } from "notistack";
 
-export default function PeripheralManager({openPane}) {
-    
-    const { enqueueSnackbar } = useSnackbar();
-    // can state
+export default function PeripheralManager({ openPane }) {
+  const { enqueueSnackbar } = useSnackbar();
+  // can state
   const [canState, setcanState] = useState({
     driveState: "idle", // idle, connecting, active
     armState: "idle", // idle, connecting, active
     scienceState: "idle", // idle, connecting, active
     gpsState: "idle", // idle, connecting, active
+    uartMode: "???", // ???, CAN, UART
     loading: true, // lock buttons, dropdowns when refreshing can data
     canIds: [], // array with every possible serial device
     driveId: "disconnect", // selected can id in dropdown or disconnect
@@ -27,8 +27,8 @@ export default function PeripheralManager({openPane}) {
     scienceId: "disconnect", // selected can id in dropdown or disconnect
     gpsId: "disconnect", // selected can id in dropdown or disconnect
   });
-  
-    function requestCanInfo() {
+
+  function requestCanInfo() {
     // lock the ui so user can't do anything while loading
     setcanState((prev) => ({
       ...prev,
@@ -43,6 +43,7 @@ export default function PeripheralManager({openPane}) {
         armId: data["armId"],
         scienceId: data["scienceId"],
         gpsId: data["gpsId"],
+        uartMode: data["uartMode"],
         // assignment if connected or not by text
         driveState: data["driveId"] !== "disconnect" ? "active" : "idle",
         armState: data["armId"] !== "disconnect" ? "active" : "idle",
@@ -256,7 +257,7 @@ export default function PeripheralManager({openPane}) {
   return (
     <div>
       <Typography sx={{ color: "black", mt: -1 }} variant="h6">
-        CAN CONNECTIONS
+        PERIPHERAL MANAGER
       </Typography>
       <Box sx={{ display: "flex", flexDirection: "row", gap: 1 }}>
         <Button
@@ -284,13 +285,15 @@ export default function PeripheralManager({openPane}) {
         </Button>
       </Box>
 
-      {/* DRIVE CAN CONNECTION */}
+      {/* DRIVE CONNECTION */}
       <Box sx={{ display: "flex", flexDirection: "row", gap: 1, mt: 1 }}>
         <FormControl sx={{ flex: 1 }} size="small">
-          <InputLabel id="demo-simple-select-label">DRIVE</InputLabel>
+          <InputLabel id="demo-simple-select-label">
+            DRIVE over {canState.uartMode}
+          </InputLabel>
           <Select
             value={canState.driveId}
-            label="DRIVE"
+            label={"DRIVE over " + canState.uartMode}
             disabled={canState.loading || canState.driveState != "idle"}
             onChange={(event) =>
               setcanState((prev) => ({

--- a/src/components/socket.io/PeripheralManager.jsx
+++ b/src/components/socket.io/PeripheralManager.jsx
@@ -288,12 +288,13 @@ export default function PeripheralManager({ openPane }) {
       {/* DRIVE CONNECTION */}
       <Box sx={{ display: "flex", flexDirection: "row", gap: 1, mt: 1 }}>
         <FormControl sx={{ flex: 1 }} size="small">
-          <InputLabel id="demo-simple-select-label">
+          <InputLabel id="drive-dropdown-peripheral-id">
             DRIVE over {canState.uartMode}
           </InputLabel>
           <Select
             value={canState.driveId}
             label={"DRIVE over " + canState.uartMode}
+            labelId="drive-dropdown-peripheral-id"
             disabled={canState.loading || canState.driveState != "idle"}
             onChange={(event) =>
               setcanState((prev) => ({
@@ -340,10 +341,11 @@ export default function PeripheralManager({ openPane }) {
       {/* ARM CAN CONNECTION */}
       <Box sx={{ display: "flex", flexDirection: "row", gap: 1, mt: 1 }}>
         <FormControl sx={{ flex: 1 }} size="small">
-          <InputLabel id="demo-simple-select-label">ARM</InputLabel>
+          <InputLabel id="arm-dropdown-peripheral-id">ARM</InputLabel>
           <Select
             value={canState.armId}
             label="ARM"
+            labelId="arm-dropdown-peripheral-id"
             disabled={canState.loading || canState.armState != "idle"}
             onChange={(event) =>
               setcanState((prev) => ({
@@ -387,10 +389,11 @@ export default function PeripheralManager({ openPane }) {
       {/* SCIENCE CAN CONNECTION */}
       <Box sx={{ display: "flex", flexDirection: "row", gap: 1, mt: 1 }}>
         <FormControl sx={{ flex: 1 }} size="small">
-          <InputLabel id="demo-simple-select-label">SCIENCE</InputLabel>
+          <InputLabel id="science-dropdown-peripheral-id">SCIENCE</InputLabel>
           <Select
             value={canState.scienceId}
             label="SCIENCE"
+            labelId="science-dropdown-peripheral-id"
             disabled={canState.loading || canState.scienceState != "idle"}
             onChange={(event) =>
               setcanState((prev) => ({
@@ -436,10 +439,11 @@ export default function PeripheralManager({ openPane }) {
       {/* GPS CONNECTION */}
       <Box sx={{ display: "flex", flexDirection: "row", gap: 1, mt: 1 }}>
         <FormControl sx={{ flex: 1 }} size="small">
-          <InputLabel id="demo-simple-select-label">GPS</InputLabel>
+          <InputLabel id="gps-dropdown-peripheral-id">GPS</InputLabel>
           <Select
             value={canState.gpsId}
             label="GPS"
+            labelId="gps-dropdown-peripheral-id"
             disabled={canState.loading || canState.gpsState != "idle"}
             onChange={(event) =>
               setcanState((prev) => ({


### PR DESCRIPTION
- Remove user confusion over whether CAN or UART is being used for Drive.
- Now shown next to the name.

<img width="291" height="175" alt="Screenshot 2026-06-28 at 11 02 44 PM" src="https://github.com/user-attachments/assets/31729d17-725e-456e-a4f2-ef2ece320902" />
<img width="288" height="172" alt="Screenshot 2026-06-28 at 11 03 09 PM" src="https://github.com/user-attachments/assets/2c3a8ec5-0a16-4c6d-9cde-5762bc490753" />
