### PR TITLE
Peripheral & Serial Context, Serial UI

### DIFF
--- a/server/py_server.py
+++ b/server/py_server.py
@@ -7,7 +7,6 @@ import asyncio
 import signal
 import sys
 import subprocess
-import os
 from metrics import cpuloop, register_metric_events
 from drive import read_drive_can_loop, send_drive_status_request
 from uart_drive_serial import UartDriveSerial
@@ -205,13 +204,13 @@ async def connectDrive(sid,data):
         if USE_UART_DRIVE:
             serial_ports["drive"] = UartDriveSerial(data)
             print("Drive UART connected.")
-            await sio.emit('forcecanrefresh', skip_sid=sid)
         else:
             serial_ports["drive"] = CanSerial(data)
             print("Drive CAN connected.")
-            await sio.emit('forcecanrefresh', skip_sid=sid)
+            
 
         serial_ports["driveId"] = data
+        await sio.emit('forcecanrefresh', skip_sid=sid)
         return("OK")
     except Exception as e:
         print("FAILURE TO CONNECT DRIVE: " + str(e))
@@ -303,7 +302,7 @@ async def connectScience(sid,data):
         await sio.emit('forcecanrefresh', skip_sid=sid)
         return("OK")
     except Exception as e:
-        print("FAILURE TO CONNECT DRIVE: " + str(e))
+        print("FAILURE TO CONNECT SCIENCE: " + str(e))
         await sio.emit('forcecanrefresh', skip_sid=sid)
         return("ERROR")
 

--- a/server/py_server.py
+++ b/server/py_server.py
@@ -7,6 +7,7 @@ import asyncio
 import signal
 import sys
 import subprocess
+import os
 from metrics import cpuloop, register_metric_events
 from drive import read_drive_can_loop, send_drive_status_request
 from uart_drive_serial import UartDriveSerial
@@ -175,6 +176,13 @@ async def getCanInfo(sid):
         if( (port.device.find("serial") != -1) or (port.device.find("COM")) != -1 or (port.device.find("tty") != -1) ):
             # loose check to remove system serial interfaces
             canIds_arr.append(port.device)
+
+    virtual_ports = ["/dev/ttys004", "/dev/ttys005"]
+
+    for virtual_port in virtual_ports:
+        if os.path.exists(virtual_port):
+            print(f"Discovered virtual serial port: {virtual_port}")
+            canIds_arr.append(virtual_port)
     data = {
     'status': "OK",
     'canIds' : canIds_arr,

--- a/server/py_server.py
+++ b/server/py_server.py
@@ -211,14 +211,17 @@ async def connectDrive(sid,data):
         if USE_UART_DRIVE:
             serial_ports["drive"] = UartDriveSerial(data)
             print("Drive UART connected.")
+            await sio.emit('forcecanrefresh', skip_sid=sid)
         else:
             serial_ports["drive"] = CanSerial(data)
             print("Drive CAN connected.")
+            await sio.emit('forcecanrefresh', skip_sid=sid)
 
         serial_ports["driveId"] = data
         return("OK")
     except Exception as e:
         print("FAILURE TO CONNECT DRIVE: " + str(e))
+        await sio.emit('forcecanrefresh', skip_sid=sid)
         return("ERROR")
 
 @sio.event
@@ -231,12 +234,14 @@ async def disconnectDrive(sid):
             serial_ports["drive"] = None
             serial_ports["driveId"] = "disconnect"
             print("Drive serial closed.")
+            await sio.emit('forcecanrefresh', skip_sid=sid)
             return("OK")
         else:
             print("Drive was never connected.")
             return("ERROR")
     except Exception:
         print("DRIVE WAS NOT DISCONNECTED!!!")
+        await sio.emit('forcecanrefresh', skip_sid=sid)
         return("ERROR")
         pass
 
@@ -259,11 +264,13 @@ async def connectArm(sid,data):
         serial_ports["arm"] = CanSerial(data)
         serial_ports["armId"] = data
         print("Arm connected.")
+        await sio.emit('forcecanrefresh', skip_sid=sid)
         return "OK"
     except Exception as e:
         serial_ports["arm"] = None
         serial_ports["armId"] = "disconnect"
         print("FAILURE TO CONNECT ARM: " + str(e))
+        await sio.emit('forcecanrefresh', skip_sid=sid)
         return "ERROR"
 
 @sio.event
@@ -277,11 +284,13 @@ async def disconnectArm(sid):
         serial_ports["arm"] = None
         serial_ports["armId"] = "disconnect"
         print("Arm serial closed.")
+        await sio.emit('forcecanrefresh', skip_sid=sid)
         return "OK"
     except Exception:
         serial_ports["arm"] = None
         serial_ports["armId"] = "disconnect"
         print("ARM WAS NOT DISCONNECTED CLEANLY!!!")
+        await sio.emit('forcecanrefresh', skip_sid=sid)
         return "ERROR"
 
 @sio.event
@@ -297,9 +306,11 @@ async def connectScience(sid,data):
         serial_ports["science"] = CanSerial(data)
         serial_ports["scienceId"] = data
         print("Science connected.")
+        await sio.emit('forcecanrefresh', skip_sid=sid)
         return("OK")
     except Exception as e:
         print("FAILURE TO CONNECT DRIVE: " + str(e))
+        await sio.emit('forcecanrefresh', skip_sid=sid)
         return("ERROR")
 
 @sio.event
@@ -312,12 +323,14 @@ async def disconnectScience(sid):
             serial_ports["science"] = None
             serial_ports["scienceId"] = "disconnect"
             print("Science serial closed.")
+            await sio.emit('forcecanrefresh', skip_sid=sid)
             return("OK")
         else:
             print("Science was never connected.")
             return("ERROR")
     except Exception:
         print("SCIENCE WAS NOT DISCONNECTED!!!")
+        await sio.emit('forcecanrefresh', skip_sid=sid)
         return("ERROR")
         pass
 
@@ -334,9 +347,11 @@ async def connectGPS(sid, data):
         serial_ports["gps"] = ZEDF9P(data, 57600) 
         serial_ports["gpsId"] = data
         print("GPS connected.")
+        await sio.emit('forcecanrefresh', skip_sid=sid)
         return("OK")
     except Exception as e:
         print("FAILURE TO CONNECT GPS: " + str(e))
+        await sio.emit('forcecanrefresh', skip_sid=sid)
         return("ERROR")
 
 @sio.event
@@ -348,12 +363,14 @@ async def disconnectGPS(sid):
             serial_ports["gps"] = None
             serial_ports["gpsId"] = "disconnect"
             print("GPS serial closed.")
+            await sio.emit('forcecanrefresh', skip_sid=sid)
             return("OK")
         else:
             print("GPS was never connected.")
             return("ERROR")
     except Exception:
         print("GPS WAS NOT DISCONNECTED!!!")
+        await sio.emit('forcecanrefresh', skip_sid=sid)
         return("ERROR")
         pass
 

--- a/server/py_server.py
+++ b/server/py_server.py
@@ -18,6 +18,7 @@ from autonomy import get_autonomy_states
 from gps import ZEDF9P, GPS_Data, GNRMC, read_gps_data, send_fake_gps_data
 from arm import dump_session_log
 from shutdown import register_shutdown_commands
+from serial_console import SerialConsole, register_serial_console_events
 
 print("\033[0m----------------")
 
@@ -80,6 +81,7 @@ serial_ports = {
     "science": None,
     "scienceId" : "disconnect"
 }
+serial_console = SerialConsole()
 
 
 
@@ -96,6 +98,7 @@ def shutdown():
     if shutting_down:
         return
     shutting_down = True
+    serial_console.close()
     print("----------------")
     print("\nShutting down... ")
     #drive
@@ -383,6 +386,7 @@ register_drive_events(sio,serial_ports)
 register_arm_events(sio, serial_ports)
 register_camera_pt_events(sio,serial_ports)
 register_shutdown_commands(sio)
+register_serial_console_events(sio, serial_console)
 
 # =================== Start Server ===================
 

--- a/server/py_server.py
+++ b/server/py_server.py
@@ -180,12 +180,6 @@ async def getCanInfo(sid):
             # loose check to remove system serial interfaces
             canIds_arr.append(port.device)
 
-    virtual_ports = ["/dev/ttys004", "/dev/ttys005"]
-
-    for virtual_port in virtual_ports:
-        if os.path.exists(virtual_port):
-            print(f"Discovered virtual serial port: {virtual_port}")
-            canIds_arr.append(virtual_port)
     data = {
     'status': "OK",
     'canIds' : canIds_arr,

--- a/server/serial_console.py
+++ b/server/serial_console.py
@@ -170,6 +170,7 @@ def register_serial_console_events(sio, console):
             await asyncio.to_thread(console.set_dtr, True)
             await asyncio.sleep(duration_ms / 1000)
             await asyncio.to_thread(console.set_dtr, False)
+            await sio.emit("serialConsoleStatus", console.info())
             return {"status": "OK"}
         except Exception as error:
             return {"status": "ERROR", "message": str(error)}

--- a/server/serial_console.py
+++ b/server/serial_console.py
@@ -37,10 +37,10 @@ class SerialConsole:
         )
         self.port_id = port_id
         self.baudrate = baudrate
-        self.port.dtr = False
-        self.port.rts = False
-        self.dtr = False
-        self.rts = False
+        #self.port.dtr = False
+        #self.port.rts = False
+        #self.dtr = False
+        #self.rts = False
 
     def close(self):
         if self.port is not None:

--- a/server/serial_console.py
+++ b/server/serial_console.py
@@ -37,10 +37,10 @@ class SerialConsole:
         )
         self.port_id = port_id
         self.baudrate = baudrate
-        #self.port.dtr = False
-        #self.port.rts = False
-        #self.dtr = False
-        #self.rts = False
+        self.port.dtr = False
+        self.port.rts = False
+        self.dtr = False
+        self.rts = False
 
     def close(self):
         if self.port is not None:

--- a/server/serial_console.py
+++ b/server/serial_console.py
@@ -1,0 +1,175 @@
+import asyncio
+import base64
+
+import serial
+from serial.tools import list_ports
+
+
+class SerialConsole:
+    def __init__(self):
+        self.port = None
+        self.port_id = "disconnect"
+        self.baudrate = 115200
+        self.dtr = False
+        self.rts = False
+        self.reader_started = False
+
+    def info(self):
+        return {
+            "status": "OK",
+            "ports": [port.device for port in list_ports.comports()],
+            "portId": self.port_id,
+            "baudrate": self.baudrate,
+            "connected": self.port is not None and self.port.is_open,
+            "dtr": self.dtr,
+            "rts": self.rts,
+        }
+
+    def open(self, port_id, baudrate):
+        self.close()
+        self.port = serial.Serial(
+            port_id,
+            baudrate=baudrate,
+            timeout=0.1,
+            write_timeout=1,
+            rtscts=False,
+            dsrdtr=False,
+        )
+        self.port_id = port_id
+        self.baudrate = baudrate
+        self.port.dtr = False
+        self.port.rts = False
+        self.dtr = False
+        self.rts = False
+
+    def close(self):
+        if self.port is not None:
+            try:
+                self.port.close()
+            finally:
+                self.port = None
+                self.port_id = "disconnect"
+                self.dtr = False
+                self.rts = False
+
+    def write(self, data):
+        if self.port is None or not self.port.is_open:
+            raise RuntimeError("Serial console is not connected")
+        self.port.write(data)
+
+    def set_dtr(self, enabled):
+        if self.port is None or not self.port.is_open:
+            raise RuntimeError("Serial console is not connected")
+        self.port.dtr = enabled
+        self.dtr = enabled
+
+    def set_rts(self, enabled):
+        if self.port is None or not self.port.is_open:
+            raise RuntimeError("Serial console is not connected")
+        self.port.rts = enabled
+        self.rts = enabled
+
+    def read(self):
+        if self.port is None or not self.port.is_open:
+            return b""
+        return self.port.read(4096)
+
+
+async def serial_console_read_loop(console, sio):
+    while True:
+        try:
+            if console.port is None or not console.port.is_open:
+                await asyncio.sleep(0.1)
+                continue
+
+            data = await asyncio.to_thread(console.read)
+            if data:
+                await sio.emit(
+                    "serialConsoleData",
+                    {"data": base64.b64encode(data).decode("ascii")},
+                )
+        except Exception as error:
+            console.close()
+            await sio.emit("serialConsoleStatus", console.info())
+            await sio.emit("serialConsoleError", {"message": str(error)})
+            await asyncio.sleep(0.1)
+
+
+def register_serial_console_events(sio, console):
+    @sio.event
+    async def getSerialConsoleInfo(sid):
+        return console.info()
+
+    @sio.event
+    async def openSerialConsole(sid, data):
+        try:
+            port_id = data.get("portId", "")
+            baudrate = int(data.get("baudrate", 115200))
+            if not port_id or baudrate <= 0:
+                raise ValueError("A serial port and positive baud rate are required")
+
+            await asyncio.to_thread(console.open, port_id, baudrate)
+            if not console.reader_started:
+                console.reader_started = True
+                sio.start_background_task(serial_console_read_loop, console, sio)
+            await sio.emit("serialConsoleStatus", console.info())
+            return {"status": "OK"}
+        except Exception as error:
+            console.close()
+            return {"status": "ERROR", "message": str(error)}
+
+    @sio.event
+    async def closeSerialConsole(sid):
+        try:
+            await asyncio.to_thread(console.close)
+            await sio.emit("serialConsoleStatus", console.info())
+            return {"status": "OK"}
+        except Exception as error:
+            return {"status": "ERROR", "message": str(error)}
+
+    @sio.event
+    async def writeSerialConsole(sid, data):
+        try:
+            encoded = data.get("data", "")
+            payload = base64.b64decode(encoded, validate=True)
+            if len(payload) > 16_384:
+                raise ValueError("Serial writes are limited to 16 KiB")
+            await asyncio.to_thread(console.write, payload)
+            return {"status": "OK"}
+        except Exception as error:
+            return {"status": "ERROR", "message": str(error)}
+
+    @sio.event
+    async def setSerialConsoleDtr(sid, data):
+        try:
+            enabled = data.get("enabled")
+            if not isinstance(enabled, bool):
+                raise ValueError("DTR state must be a boolean")
+            await asyncio.to_thread(console.set_dtr, enabled)
+            return {"status": "OK", "enabled": enabled}
+        except Exception as error:
+            return {"status": "ERROR", "message": str(error)}
+
+    @sio.event
+    async def setSerialConsoleRts(sid, data):
+        try:
+            enabled = data.get("enabled")
+            if not isinstance(enabled, bool):
+                raise ValueError("RTS state must be a boolean")
+            await asyncio.to_thread(console.set_rts, enabled)
+            return {"status": "OK", "enabled": enabled}
+        except Exception as error:
+            return {"status": "ERROR", "message": str(error)}
+
+    @sio.event
+    async def pulseSerialConsoleDtr(sid, data):
+        try:
+            duration_ms = int(data.get("durationMs", 200))
+            if duration_ms < 10 or duration_ms > 5000:
+                raise ValueError("DTR pulse must be between 10 and 5000 ms")
+            await asyncio.to_thread(console.set_dtr, True)
+            await asyncio.sleep(duration_ms / 1000)
+            await asyncio.to_thread(console.set_dtr, False)
+            return {"status": "OK"}
+        except Exception as error:
+            return {"status": "ERROR", "message": str(error)}

--- a/src/components/serial/SerialConsole.jsx
+++ b/src/components/serial/SerialConsole.jsx
@@ -1,4 +1,3 @@
-import { useCallback, useEffect, useRef, useState } from "react";
 import {
   Alert,
   Box,
@@ -15,162 +14,39 @@ import {
   Typography,
 } from "@mui/material";
 import { robotsocket, useRobotSocketStatus } from "../socket.io/socket";
+import { useSerial } from "../../contexts/SerialContext";
 import { usePeripherals } from "../../contexts/PeripheralContext";
 
-const textEncoder = new TextEncoder();
-
-function encodeBytes(bytes) {
-  let binary = "";
-  for (const byte of bytes) binary += String.fromCharCode(byte);
-  return btoa(binary);
-}
-
-function decodeBytes(encoded) {
-  const binary = atob(encoded);
-  return Uint8Array.from(binary, (character) => character.charCodeAt(0));
-}
-
 export default function SerialConsole() {
-  const { serialState, setserialState, canState } = usePeripherals();
-  const serverConnected = useRobotSocketStatus();
-  const decoderRef = useRef(new TextDecoder());
-  const outputRef = useRef(null);
-
-  const [selectedPort, setSelectedPort] = useState("disconnect");
-  const [baudrate, setBaudrate] = useState(115200);
-  const [input, setInput] = useState("");
-  const [output, setOutput] = useState("");
-  const [busy, setBusy] = useState(false);
-  const [error, setError] = useState("");
-  const [dtr, setDtr] = useState(false);
-  const [rts, setRts] = useState(false);
-  const [appendCarriageReturn, setAppendCarriageReturn] = useState(false);
-  const [appendNewline, setAppendNewline] = useState(true);
-  const [localEcho, setLocalEcho] = useState(false);
-  const [autoScroll, setAutoScroll] = useState(true);
-
-  function applyInfo(nextInfo) {
-    setserialState(nextInfo);
-    setSelectedPort(nextInfo.portId);
-    setBaudrate(nextInfo.baudrate);
-    setDtr(nextInfo.dtr ?? false);
-    setRts(nextInfo.rts ?? false);
-  }
-
-  const refresh = useCallback(() => {
-    robotsocket.emit("getSerialConsoleInfo", (response) => {
-      if (response) applyInfo(response);
-    });
-  }, []);
-
-  useEffect(() => {
-    const handleData = ({ data }) => {
-      const text = decoderRef.current.decode(decodeBytes(data), {
-        stream: true,
-      });
-      setOutput((previous) => (previous + text).slice(-100_000));
-    };
-    const handleStatus = (status) => applyInfo(status);
-    const handleError = ({ message }) => setError(message);
-
-    robotsocket.on("serialConsoleData", handleData);
-    robotsocket.on("serialConsoleStatus", handleStatus);
-    robotsocket.on("serialConsoleError", handleError);
-    refresh();
-
-    return () => {
-      robotsocket.off("serialConsoleData", handleData);
-      robotsocket.off("serialConsoleStatus", handleStatus);
-      robotsocket.off("serialConsoleError", handleError);
-    };
-  }, [refresh]);
-
-  useEffect(() => {
-    if (autoScroll && outputRef.current) {
-      outputRef.current.scrollTop = outputRef.current.scrollHeight;
-    }
-  }, [output, autoScroll]);
-
-  function openConsole() {
-    setBusy(true);
-    setError("");
-    robotsocket.emit(
-      "openSerialConsole",
-      { portId: selectedPort, baudrate: Number(baudrate) },
-      (response) => {
-        setBusy(false);
-        if (response?.status !== "OK") {
-          setError(response?.message || "Unable to open serial console");
-        } else {
-          refresh();
-        }
-      },
-    );
-  }
-
-  function closeConsole() {
-    setBusy(true);
-    robotsocket.emit("closeSerialConsole", (response) => {
-      setBusy(false);
-      if (response?.status !== "OK") {
-        setError(response?.message || "Unable to close serial console");
-      }
-    });
-  }
-
-  function sendInput() {
-    if (!input) return;
-    const ending = `${appendCarriageReturn ? "\r" : ""}${appendNewline ? "\n" : ""}`;
-    const payload = textEncoder.encode(`${input}${ending}`);
-    robotsocket.emit(
-      "writeSerialConsole",
-      { data: encodeBytes(payload) },
-      (response) => {
-        if (response?.status !== "OK") {
-          setError(response?.message || "Serial write failed");
-        }
-      },
-    );
-    if (localEcho) {
-      setOutput((previous) => (previous + input + ending).slice(-100_000));
-    }
-    setInput("");
-  }
-
-  function updateRts(enabled) {
-    robotsocket.emit("setSerialConsoleRts", { enabled }, (response) => {
-      if (response?.status === "OK") {
-        setRts(enabled);
-      } else {
-        setError(response?.message || "Unable to set RTS");
-      }
-    });
-  }
-
-  function updateDtr(enabled) {
-    robotsocket.emit("setSerialConsoleDtr", { enabled }, (response) => {
-      if (response?.status === "OK") {
-        setDtr(enabled);
-      } else {
-        setError(response?.message || "Unable to set DTR");
-      }
-    });
-  }
-
-  function pulseDtr() {
-    robotsocket.emit(
-      "pulseSerialConsoleDtr",
-      { durationMs: 200 },
-      (response) => {
-        if (response?.status === "OK") {
-          setDtr(true);
-        } else {
-          setError(response?.message || "Unable to pulse DTR");
-        }
-      },
-    );
-  }
-
+  const serverConnected = useRobotSocketStatus;
+  const {
+    pulseDtr,
+    updateDtr,
+    updateRts,
+    sendInput,
+    closeConsole,
+    openConsole,
+    serialState,
+    baudrate,
+    refresh,
+    autoScroll,
+    outputRef,
+    output,
+    input,
+    appendCarriageReturn,
+    appendNewline,
+    localEcho,
+    selectedPort,
+    setAppendNewline,
+    setLocalEcho,
+    setAutoScroll,
+    setAppendCarriageReturn,
+    busy,
+    error,
+    dtr,
+    rts,
+  } = useSerial();
+  const { canState } = usePeripherals();
   return (
     <Paper
       sx={{

--- a/src/components/serial/SerialConsole.jsx
+++ b/src/components/serial/SerialConsole.jsx
@@ -29,6 +29,7 @@ export default function SerialConsole() {
     serialState,
     baudrate,
     refresh,
+    setBaudrate,
     autoScroll,
     outputRef,
     output,
@@ -36,17 +37,20 @@ export default function SerialConsole() {
     appendCarriageReturn,
     appendNewline,
     localEcho,
+    setSelectedPort,
     selectedPort,
     setAppendNewline,
     setLocalEcho,
     setAutoScroll,
     setAppendCarriageReturn,
+    setError,
     busy,
     error,
     dtr,
     rts,
   } = useSerial();
   const { canState } = usePeripherals();
+  
   return (
     <Paper
       sx={{

--- a/src/components/serial/SerialConsole.jsx
+++ b/src/components/serial/SerialConsole.jsx
@@ -1,0 +1,338 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  Alert,
+  Box,
+  Button,
+  Checkbox,
+  FormControl,
+  FormControlLabel,
+  InputLabel,
+  MenuItem,
+  Paper,
+  Select,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { robotsocket, useRobotSocketStatus } from "../socket.io/socket";
+
+const textEncoder = new TextEncoder();
+
+function encodeBytes(bytes) {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary);
+}
+
+function decodeBytes(encoded) {
+  const binary = atob(encoded);
+  return Uint8Array.from(binary, (character) => character.charCodeAt(0));
+}
+
+export default function SerialConsole() {
+  const serverConnected = useRobotSocketStatus();
+  const decoderRef = useRef(new TextDecoder());
+  const outputRef = useRef(null);
+  const [info, setInfo] = useState({
+    ports: [],
+    portId: "disconnect",
+    baudrate: 115200,
+    connected: false,
+    dtr: false,
+    rts: false,
+  });
+  const [selectedPort, setSelectedPort] = useState("disconnect");
+  const [baudrate, setBaudrate] = useState(115200);
+  const [input, setInput] = useState("");
+  const [output, setOutput] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+  const [dtr, setDtr] = useState(false);
+  const [rts, setRts] = useState(false);
+  const [appendCarriageReturn, setAppendCarriageReturn] = useState(false);
+  const [appendNewline, setAppendNewline] = useState(true);
+  const [localEcho, setLocalEcho] = useState(false);
+
+  function applyInfo(nextInfo) {
+    setInfo(nextInfo);
+    setSelectedPort(nextInfo.portId);
+    setBaudrate(nextInfo.baudrate);
+    setDtr(nextInfo.dtr ?? false);
+    setRts(nextInfo.rts ?? false);
+  }
+
+  const refresh = useCallback(() => {
+    robotsocket.emit("getSerialConsoleInfo", (response) => {
+      if (response) applyInfo(response);
+    });
+  }, []);
+
+  useEffect(() => {
+    const handleData = ({ data }) => {
+      const text = decoderRef.current.decode(decodeBytes(data), { stream: true });
+      setOutput((previous) => (previous + text).slice(-100_000));
+    };
+    const handleStatus = (status) => applyInfo(status);
+    const handleError = ({ message }) => setError(message);
+
+    robotsocket.on("serialConsoleData", handleData);
+    robotsocket.on("serialConsoleStatus", handleStatus);
+    robotsocket.on("serialConsoleError", handleError);
+    refresh();
+
+    return () => {
+      robotsocket.off("serialConsoleData", handleData);
+      robotsocket.off("serialConsoleStatus", handleStatus);
+      robotsocket.off("serialConsoleError", handleError);
+    };
+  }, [refresh]);
+
+  useEffect(() => {
+    if (outputRef.current) {
+      outputRef.current.scrollTop = outputRef.current.scrollHeight;
+    }
+  }, [output]);
+
+  function openConsole() {
+    setBusy(true);
+    setError("");
+    robotsocket.emit(
+      "openSerialConsole",
+      { portId: selectedPort, baudrate: Number(baudrate) },
+      (response) => {
+        setBusy(false);
+        if (response?.status !== "OK") {
+          setError(response?.message || "Unable to open serial console");
+        } else {
+          refresh();
+        }
+      },
+    );
+  }
+
+  function closeConsole() {
+    setBusy(true);
+    robotsocket.emit("closeSerialConsole", (response) => {
+      setBusy(false);
+      if (response?.status !== "OK") {
+        setError(response?.message || "Unable to close serial console");
+      }
+    });
+  }
+
+  function sendInput() {
+    if (!input) return;
+    const ending =
+      `${appendCarriageReturn ? "\r" : ""}${appendNewline ? "\n" : ""}`;
+    const payload = textEncoder.encode(`${input}${ending}`);
+    robotsocket.emit(
+      "writeSerialConsole",
+      { data: encodeBytes(payload) },
+      (response) => {
+        if (response?.status !== "OK") {
+          setError(response?.message || "Serial write failed");
+        }
+      },
+    );
+    if (localEcho) {
+      setOutput((previous) => (previous + input + ending).slice(-100_000));
+    }
+    setInput("");
+  }
+
+  function updateRts(enabled) {
+    robotsocket.emit("setSerialConsoleRts", { enabled }, (response) => {
+      if (response?.status === "OK") {
+        setRts(enabled);
+      } else {
+        setError(response?.message || "Unable to set RTS");
+      }
+    });
+  }
+
+  function updateDtr(enabled) {
+    robotsocket.emit("setSerialConsoleDtr", { enabled }, (response) => {
+      if (response?.status === "OK") {
+        setDtr(enabled);
+      } else {
+        setError(response?.message || "Unable to set DTR");
+      }
+    });
+  }
+
+  function pulseDtr() {
+    robotsocket.emit(
+      "pulseSerialConsoleDtr",
+      { durationMs: 200 },
+      (response) => {
+        if (response?.status === "OK") {
+          setDtr(true);
+        } else {
+          setError(response?.message || "Unable to pulse DTR");
+        }
+      },
+    );
+  }
+
+  return (
+    <Paper
+      sx={{
+        m: 1,
+        p: 2,
+        flex: 1,
+        minHeight: 0,
+        overflow: "auto",
+        display: "flex",
+        flexDirection: "column",
+      }}
+    >
+      <Stack spacing={2} sx={{ flex: 1, minHeight: 0 }}>
+        <Box>
+          <Typography variant="h5">Serial Console</Typography>
+        </Box>
+
+        {!serverConnected && <Alert severity="warning">Robot server offline</Alert>}
+        {error && (
+          <Alert severity="error" onClose={() => setError("")}>
+            {error}
+          </Alert>
+        )}
+
+        <Stack direction={{ xs: "column", md: "row" }} spacing={1}>
+          <FormControl size="small" sx={{ minWidth: 280 }}>
+            <InputLabel>Server serial port</InputLabel>
+            <Select
+              value={selectedPort}
+              label="Server serial port"
+              disabled={info.connected || busy}
+              onChange={(event) => setSelectedPort(event.target.value)}
+            >
+              <MenuItem value="disconnect">Select a port</MenuItem>
+              {info.ports.map((portId) => (
+                <MenuItem key={portId} value={portId}>
+                  {portId}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          <TextField
+            size="small"
+            label="Baud rate"
+            type="number"
+            value={baudrate}
+            disabled={info.connected || busy}
+            onChange={(event) => setBaudrate(event.target.value)}
+          />
+          <Button variant="outlined" onClick={refresh} disabled={busy}>
+            Refresh
+          </Button>
+          <Button
+            variant="contained"
+            color={info.connected ? "error" : "success"}
+            disabled={
+              busy || !serverConnected || selectedPort === "disconnect"
+            }
+            onClick={info.connected ? closeConsole : openConsole}
+          >
+            {info.connected ? "Disconnect" : "Connect"}
+          </Button>
+        </Stack>
+
+        <Box
+          ref={outputRef}
+          component="pre"
+          sx={{
+            bgcolor: "#101418",
+            color: "#d7ffd9",
+            p: 2,
+            m: 0,
+            flex: "1 1 0",
+            height: { xs: 320, md: "50vh" },
+            minHeight: 240,
+            maxHeight: "60vh",
+            overflow: "auto",
+            borderRadius: 1,
+            fontFamily: "monospace",
+            whiteSpace: "pre-wrap",
+            overflowWrap: "anywhere",
+          }}
+        >
+          {output || "Waiting for serial output…"}
+        </Box>
+
+        <Stack direction="row" spacing={1}>
+          <TextField
+            fullWidth
+            size="small"
+            label="Console input"
+            value={input}
+            disabled={!info.connected}
+            onChange={(event) => setInput(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter") {
+                event.preventDefault();
+                sendInput();
+              }
+            }}
+          />
+          <Button variant="contained" disabled={!info.connected} onClick={sendInput}>
+            Send
+          </Button>
+          <Button variant="outlined" onClick={() => setOutput("")}>
+            Clear
+          </Button>
+        </Stack>
+
+        <Stack direction={{ xs: "column", sm: "row" }} spacing={1}>
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={appendCarriageReturn}
+                onChange={(event) => setAppendCarriageReturn(event.target.checked)}
+              />
+            }
+            label="Append CR"
+          />
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={appendNewline}
+                onChange={(event) => setAppendNewline(event.target.checked)}
+              />
+            }
+            label="Append LF"
+          />
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={localEcho}
+                onChange={(event) => setLocalEcho(event.target.checked)}
+              />
+            }
+            label="Local echo"
+          />
+        </Stack>
+
+        <Stack direction={{ xs: "column", sm: "row" }} spacing={1} alignItems="center">
+          <Typography>DTR: {dtr ? "asserted" : "cleared"}</Typography>
+          <Button disabled={!info.connected} onClick={() => updateDtr(true)}>
+            Assert (ON)
+          </Button>
+          <Button disabled={!info.connected} onClick={() => updateDtr(false)}>
+            Clear (OFF)
+          </Button>
+          <Button disabled={!info.connected} onClick={pulseDtr}>
+            Pulse 200 ms (ON-OFF)
+          </Button>
+          <Typography>RTS: {rts ? "asserted" : "cleared"}</Typography>
+          <Button disabled={!info.connected} onClick={() => updateRts(true)}>
+            Assert RTS
+          </Button>
+          <Button disabled={!info.connected} onClick={() => updateRts(false)}>
+            Clear RTS
+          </Button>
+        </Stack>
+      </Stack>
+    </Paper>
+  );
+}

--- a/src/components/serial/SerialConsole.jsx
+++ b/src/components/serial/SerialConsole.jsx
@@ -47,6 +47,7 @@ export default function SerialConsole() {
   const [appendCarriageReturn, setAppendCarriageReturn] = useState(false);
   const [appendNewline, setAppendNewline] = useState(true);
   const [localEcho, setLocalEcho] = useState(false);
+  const [autoScroll, setAutoScroll] = useState(true);
 
   function applyInfo(nextInfo) {
     setserialState(nextInfo);
@@ -85,10 +86,10 @@ export default function SerialConsole() {
   }, [refresh]);
 
   useEffect(() => {
-    if (outputRef.current) {
+    if (autoScroll && outputRef.current) {
       outputRef.current.scrollTop = outputRef.current.scrollHeight;
     }
-  }, [output]);
+  }, [output, autoScroll]);
 
   function openConsole() {
     setBusy(true);
@@ -197,7 +198,7 @@ export default function SerialConsole() {
         )}
 
         <Stack direction={{ xs: "column", md: "row" }} spacing={1}>
-          <FormControl size="small" sx={{ minWidth: 280 }}>
+          <FormControl size="small" sx={{ minWidth: 150, flex: 1 }}>
             <InputLabel>Server serial port</InputLabel>
             <Select
               value={selectedPort}
@@ -226,6 +227,7 @@ export default function SerialConsole() {
             size="small"
             label="Baud rate"
             type="number"
+            sx={{ width: 130 }}
             value={baudrate}
             disabled={serialState.connected || busy}
             onChange={(event) => setBaudrate(event.target.value)}
@@ -240,6 +242,15 @@ export default function SerialConsole() {
             onClick={serialState.connected ? closeConsole : openConsole}
           >
             {serialState.connected ? "Disconnect" : "Connect"}
+          </Button>
+          <Button
+            variant={autoScroll ? "contained" : "outlined"}
+            color="secondary"
+            sx={{ width: 180 }}
+            aria-pressed={autoScroll}
+            onClick={() => setAutoScroll((enabled) => !enabled)}
+          >
+            Autoscroll: {autoScroll ? "On" : "Off"}
           </Button>
         </Stack>
 
@@ -260,6 +271,9 @@ export default function SerialConsole() {
             fontFamily: "monospace",
             whiteSpace: "pre-wrap",
             overflowWrap: "anywhere",
+            userSelect: "text",
+            WebkitUserSelect: "text",
+            cursor: "text",
           }}
         >
           {output || "Waiting for serial output…"}

--- a/src/components/serial/SerialConsole.jsx
+++ b/src/components/serial/SerialConsole.jsx
@@ -31,7 +31,7 @@ function decodeBytes(encoded) {
 }
 
 export default function SerialConsole() {
-  const { info, setInfo, canState } = usePeripherals();
+  const { serialState, setserialState, canState } = usePeripherals();
   const serverConnected = useRobotSocketStatus();
   const decoderRef = useRef(new TextDecoder());
   const outputRef = useRef(null);
@@ -49,7 +49,7 @@ export default function SerialConsole() {
   const [localEcho, setLocalEcho] = useState(false);
 
   function applyInfo(nextInfo) {
-    setInfo(nextInfo);
+    setserialState(nextInfo);
     setSelectedPort(nextInfo.portId);
     setBaudrate(nextInfo.baudrate);
     setDtr(nextInfo.dtr ?? false);
@@ -202,19 +202,21 @@ export default function SerialConsole() {
             <Select
               value={selectedPort}
               label="Server serial port"
-              disabled={
-                info.connected ||
-                busy ||
-                selectedPort === canState.driveId ||
-                selectedPort === canState.armId ||
-                selectedPort === canState.scienceId ||
-                selectedPort === canState.gpsId
-              }
+              disabled={serialState.connected || busy}
               onChange={(event) => setSelectedPort(event.target.value)}
             >
               <MenuItem value="disconnect">Select a port</MenuItem>
-              {info.ports.map((portId) => (
-                <MenuItem key={portId} value={portId}>
+              {serialState.ports.map((portId) => (
+                <MenuItem
+                  key={portId}
+                  disabled={
+                    portId === canState.driveId ||
+                    portId === canState.armId ||
+                    portId === canState.scienceId ||
+                    portId === canState.gpsId
+                  }
+                  value={portId}
+                >
                   {portId}
                 </MenuItem>
               ))}
@@ -225,7 +227,7 @@ export default function SerialConsole() {
             label="Baud rate"
             type="number"
             value={baudrate}
-            disabled={info.connected || busy}
+            disabled={serialState.connected || busy}
             onChange={(event) => setBaudrate(event.target.value)}
           />
           <Button variant="contained" onClick={refresh} disabled={busy}>
@@ -233,11 +235,11 @@ export default function SerialConsole() {
           </Button>
           <Button
             variant="contained"
-            color={info.connected ? "error" : "success"}
+            color={serialState.connected ? "error" : "success"}
             disabled={busy || !serverConnected || selectedPort === "disconnect"}
-            onClick={info.connected ? closeConsole : openConsole}
+            onClick={serialState.connected ? closeConsole : openConsole}
           >
-            {info.connected ? "Disconnect" : "Connect"}
+            {serialState.connected ? "Disconnect" : "Connect"}
           </Button>
         </Stack>
 
@@ -269,7 +271,7 @@ export default function SerialConsole() {
             size="small"
             label="Console input"
             value={input}
-            disabled={!info.connected}
+            disabled={!serialState.connected}
             onChange={(event) => setInput(event.target.value)}
             onKeyDown={(event) => {
               if (event.key === "Enter") {
@@ -280,7 +282,7 @@ export default function SerialConsole() {
           />
           <Button
             variant="contained"
-            disabled={!info.connected}
+            disabled={!serialState.connected}
             onClick={sendInput}
           >
             Send
@@ -328,20 +330,32 @@ export default function SerialConsole() {
           alignItems="center"
         >
           <Typography>DTR: {dtr ? "asserted" : "cleared"}</Typography>
-          <Button disabled={!info.connected} onClick={() => updateDtr(true)}>
+          <Button
+            disabled={!serialState.connected}
+            onClick={() => updateDtr(true)}
+          >
             Assert (ON)
           </Button>
-          <Button disabled={!info.connected} onClick={() => updateDtr(false)}>
+          <Button
+            disabled={!serialState.connected}
+            onClick={() => updateDtr(false)}
+          >
             Clear (OFF)
           </Button>
-          <Button disabled={!info.connected} onClick={pulseDtr}>
+          <Button disabled={!serialState.connected} onClick={pulseDtr}>
             Pulse 200 ms (ON-OFF)
           </Button>
           <Typography>RTS: {rts ? "asserted" : "cleared"}</Typography>
-          <Button disabled={!info.connected} onClick={() => updateRts(true)}>
+          <Button
+            disabled={!serialState.connected}
+            onClick={() => updateRts(true)}
+          >
             Assert RTS
           </Button>
-          <Button disabled={!info.connected} onClick={() => updateRts(false)}>
+          <Button
+            disabled={!serialState.connected}
+            onClick={() => updateRts(false)}
+          >
             Clear RTS
           </Button>
         </Stack>

--- a/src/components/serial/SerialConsole.jsx
+++ b/src/components/serial/SerialConsole.jsx
@@ -15,6 +15,7 @@ import {
   Typography,
 } from "@mui/material";
 import { robotsocket, useRobotSocketStatus } from "../socket.io/socket";
+import { usePeripherals } from "../../contexts/PeripheralContext";
 
 const textEncoder = new TextEncoder();
 
@@ -30,17 +31,11 @@ function decodeBytes(encoded) {
 }
 
 export default function SerialConsole() {
+  const { info, setInfo, canState } = usePeripherals();
   const serverConnected = useRobotSocketStatus();
   const decoderRef = useRef(new TextDecoder());
   const outputRef = useRef(null);
-  const [info, setInfo] = useState({
-    ports: [],
-    portId: "disconnect",
-    baudrate: 115200,
-    connected: false,
-    dtr: false,
-    rts: false,
-  });
+
   const [selectedPort, setSelectedPort] = useState("disconnect");
   const [baudrate, setBaudrate] = useState(115200);
   const [input, setInput] = useState("");
@@ -69,7 +64,9 @@ export default function SerialConsole() {
 
   useEffect(() => {
     const handleData = ({ data }) => {
-      const text = decoderRef.current.decode(decodeBytes(data), { stream: true });
+      const text = decoderRef.current.decode(decodeBytes(data), {
+        stream: true,
+      });
       setOutput((previous) => (previous + text).slice(-100_000));
     };
     const handleStatus = (status) => applyInfo(status);
@@ -122,8 +119,7 @@ export default function SerialConsole() {
 
   function sendInput() {
     if (!input) return;
-    const ending =
-      `${appendCarriageReturn ? "\r" : ""}${appendNewline ? "\n" : ""}`;
+    const ending = `${appendCarriageReturn ? "\r" : ""}${appendNewline ? "\n" : ""}`;
     const payload = textEncoder.encode(`${input}${ending}`);
     robotsocket.emit(
       "writeSerialConsole",
@@ -191,7 +187,9 @@ export default function SerialConsole() {
           <Typography variant="h5">Serial Console</Typography>
         </Box>
 
-        {!serverConnected && <Alert severity="warning">Robot server offline</Alert>}
+        {!serverConnected && (
+          <Alert severity="warning">Robot server offline</Alert>
+        )}
         {error && (
           <Alert severity="error" onClose={() => setError("")}>
             {error}
@@ -204,7 +202,14 @@ export default function SerialConsole() {
             <Select
               value={selectedPort}
               label="Server serial port"
-              disabled={info.connected || busy}
+              disabled={
+                info.connected ||
+                busy ||
+                selectedPort === canState.driveId ||
+                selectedPort === canState.armId ||
+                selectedPort === canState.scienceId ||
+                selectedPort === canState.gpsId
+              }
               onChange={(event) => setSelectedPort(event.target.value)}
             >
               <MenuItem value="disconnect">Select a port</MenuItem>
@@ -223,15 +228,13 @@ export default function SerialConsole() {
             disabled={info.connected || busy}
             onChange={(event) => setBaudrate(event.target.value)}
           />
-          <Button variant="outlined" onClick={refresh} disabled={busy}>
+          <Button variant="contained" onClick={refresh} disabled={busy}>
             Refresh
           </Button>
           <Button
             variant="contained"
             color={info.connected ? "error" : "success"}
-            disabled={
-              busy || !serverConnected || selectedPort === "disconnect"
-            }
+            disabled={busy || !serverConnected || selectedPort === "disconnect"}
             onClick={info.connected ? closeConsole : openConsole}
           >
             {info.connected ? "Disconnect" : "Connect"}
@@ -275,7 +278,11 @@ export default function SerialConsole() {
               }
             }}
           />
-          <Button variant="contained" disabled={!info.connected} onClick={sendInput}>
+          <Button
+            variant="contained"
+            disabled={!info.connected}
+            onClick={sendInput}
+          >
             Send
           </Button>
           <Button variant="outlined" onClick={() => setOutput("")}>
@@ -288,7 +295,9 @@ export default function SerialConsole() {
             control={
               <Checkbox
                 checked={appendCarriageReturn}
-                onChange={(event) => setAppendCarriageReturn(event.target.checked)}
+                onChange={(event) =>
+                  setAppendCarriageReturn(event.target.checked)
+                }
               />
             }
             label="Append CR"
@@ -313,7 +322,11 @@ export default function SerialConsole() {
           />
         </Stack>
 
-        <Stack direction={{ xs: "column", sm: "row" }} spacing={1} alignItems="center">
+        <Stack
+          direction={{ xs: "column", sm: "row" }}
+          spacing={1}
+          alignItems="center"
+        >
           <Typography>DTR: {dtr ? "asserted" : "cleared"}</Typography>
           <Button disabled={!info.connected} onClick={() => updateDtr(true)}>
             Assert (ON)

--- a/src/components/serial/SerialConsole.jsx
+++ b/src/components/serial/SerialConsole.jsx
@@ -13,12 +13,12 @@ import {
   TextField,
   Typography,
 } from "@mui/material";
-import { robotsocket, useRobotSocketStatus } from "../socket.io/socket";
+import { useRobotSocketStatus } from "../socket.io/socket";
 import { useSerial } from "../../contexts/SerialContext";
 import { usePeripherals } from "../../contexts/PeripheralContext";
 
 export default function SerialConsole() {
-  const serverConnected = useRobotSocketStatus;
+  const serverConnected = useRobotSocketStatus();
   const {
     pulseDtr,
     updateDtr,
@@ -44,6 +44,8 @@ export default function SerialConsole() {
     setAutoScroll,
     setAppendCarriageReturn,
     setError,
+    setInput,
+    setOutput,
     busy,
     error,
     dtr,

--- a/src/components/socket.io/PeripheralManager.jsx
+++ b/src/components/socket.io/PeripheralManager.jsx
@@ -24,14 +24,14 @@ export default function PeripheralManager({ openPane }) {
     connectGPS, 
     disconnectGPS, 
     disconnectAll, 
-    info
+    serialState
   } = usePeripherals();
 
 
 
   useEffect(() => {
     if (openPane == "Backend") {
-      requestCanInfo(); // autoload can info
+      requestCanInfo(); // autoload can serialState
     } else {
       setcanState((prev) => ({
         ...prev,
@@ -98,7 +98,7 @@ export default function PeripheralManager({ openPane }) {
                   canId === canState.armId ||
                   canId === canState.scienceId ||
                   canId === canState.gpsId ||
-                  canId === info.portId
+                  canId === serialState.portId
                 }
                 key={canId}
                 value={canId}
@@ -150,7 +150,7 @@ export default function PeripheralManager({ openPane }) {
                   canId === canState.driveId ||
                   canId === canState.scienceId ||
                   canId === canState.gpsId ||
-                  canId === info.portId
+                  canId === serialState.portId
                 }
                 key={canId}
                 value={canId}
@@ -199,7 +199,7 @@ export default function PeripheralManager({ openPane }) {
                   canId === canState.driveId ||
                   canId === canState.armId ||
                   canId === canState.gpsId ||
-                  canId === info.portId
+                  canId === serialState.portId
                 }
                 key={canId}
                 value={canId}
@@ -250,7 +250,7 @@ export default function PeripheralManager({ openPane }) {
                   canId === canState.driveId ||
                   canId === canState.armId ||
                   canId === canState.scienceId ||
-                  canId === info.portId
+                  canId === serialState.portId
                 }
                 key={canId}
                 value={canId}

--- a/src/components/socket.io/PeripheralManager.jsx
+++ b/src/components/socket.io/PeripheralManager.jsx
@@ -23,7 +23,8 @@ export default function PeripheralManager({ openPane }) {
     disconnectScience,
     connectGPS, 
     disconnectGPS, 
-    disconnectAll
+    disconnectAll, 
+    info
   } = usePeripherals();
 
 
@@ -96,7 +97,8 @@ export default function PeripheralManager({ openPane }) {
                 disabled={
                   canId === canState.armId ||
                   canId === canState.scienceId ||
-                  canId === canState.gpsId
+                  canId === canState.gpsId ||
+                  canId === info.portId
                 }
                 key={canId}
                 value={canId}
@@ -147,7 +149,8 @@ export default function PeripheralManager({ openPane }) {
                 disabled={
                   canId === canState.driveId ||
                   canId === canState.scienceId ||
-                  canId === canState.gpsId
+                  canId === canState.gpsId ||
+                  canId === info.portId
                 }
                 key={canId}
                 value={canId}
@@ -195,7 +198,8 @@ export default function PeripheralManager({ openPane }) {
                 disabled={
                   canId === canState.driveId ||
                   canId === canState.armId ||
-                  canId === canState.gpsId
+                  canId === canState.gpsId ||
+                  canId === info.portId
                 }
                 key={canId}
                 value={canId}
@@ -245,7 +249,8 @@ export default function PeripheralManager({ openPane }) {
                 disabled={
                   canId === canState.driveId ||
                   canId === canState.armId ||
-                  canId === canState.scienceId
+                  canId === canState.scienceId ||
+                  canId === info.portId
                 }
                 key={canId}
                 value={canId}

--- a/src/components/socket.io/PeripheralManager.jsx
+++ b/src/components/socket.io/PeripheralManager.jsx
@@ -1,5 +1,4 @@
-import { robotsocket } from "./socket";
-import { useState, useEffect } from "react";
+import { useEffect } from "react";
 import Typography from "@mui/material/Typography";
 import Button from "@mui/material/Button";
 import Box from "@mui/material/Box";
@@ -9,7 +8,6 @@ import FormControl from "@mui/material/FormControl";
 import Select from "@mui/material/Select";
 import ElectricalServicesIcon from "@mui/icons-material/ElectricalServices";
 import EjectIcon from "@mui/icons-material/Eject";
-import { useSnackbar } from "notistack";
 import { usePeripherals } from "../../contexts/PeripheralContext";
 
 export default function PeripheralManager({ openPane }) {
@@ -28,8 +26,7 @@ export default function PeripheralManager({ openPane }) {
     disconnectAll
   } = usePeripherals();
 
-  const { enqueueSnackbar } = useSnackbar();
-  // can state
+
 
   useEffect(() => {
     if (openPane == "Backend") {

--- a/src/components/socket.io/PeripheralManager.jsx
+++ b/src/components/socket.io/PeripheralManager.jsx
@@ -10,237 +10,26 @@ import Select from "@mui/material/Select";
 import ElectricalServicesIcon from "@mui/icons-material/ElectricalServices";
 import EjectIcon from "@mui/icons-material/Eject";
 import { useSnackbar } from "notistack";
+import { usePeripherals } from "../../contexts/PeripheralContext";
 
 export default function PeripheralManager({ openPane }) {
+  const {
+    canState,
+    requestCanInfo,
+    setcanState,
+    connectDrive,
+    disconnectDrive,
+    connectArm, 
+    disconnectArm, 
+    connectScience, 
+    disconnectScience,
+    connectGPS, 
+    disconnectGPS, 
+    disconnectAll
+  } = usePeripherals();
+
   const { enqueueSnackbar } = useSnackbar();
   // can state
-  const [canState, setcanState] = useState({
-    driveState: "idle", // idle, connecting, active
-    armState: "idle", // idle, connecting, active
-    scienceState: "idle", // idle, connecting, active
-    gpsState: "idle", // idle, connecting, active
-    uartMode: "???", // ???, CAN, UART
-    loading: true, // lock buttons, dropdowns when refreshing can data
-    canIds: [], // array with every possible serial device
-    driveId: "disconnect", // selected can id in dropdown or disconnect
-    armId: "disconnect", // selected can id in dropdown or disconnect
-    scienceId: "disconnect", // selected can id in dropdown or disconnect
-    gpsId: "disconnect", // selected can id in dropdown or disconnect
-  });
-
-  function requestCanInfo() {
-    // lock the ui so user can't do anything while loading
-    setcanState((prev) => ({
-      ...prev,
-      loading: true,
-    }));
-    robotsocket.emit("getCanInfo", (data) => {
-      //console.log(data);
-      setcanState((prev) => ({
-        ...prev,
-        canIds: data["canIds"],
-        driveId: data["driveId"],
-        armId: data["armId"],
-        scienceId: data["scienceId"],
-        gpsId: data["gpsId"],
-        uartMode: data["uartMode"],
-        // assignment if connected or not by text
-        driveState: data["driveId"] !== "disconnect" ? "active" : "idle",
-        armState: data["armId"] !== "disconnect" ? "active" : "idle",
-        scienceState: data["scienceId"] !== "disconnect" ? "active" : "idle",
-        gpsState: data["gpsId"] !== "disconnect" ? "active" : "idle",
-        loading: false,
-      }));
-    });
-  }
-
-  function connectDrive() {
-    setcanState((prev) => ({
-      ...prev,
-      driveState: "connecting",
-    }));
-    console.log("Connecting Drive, Sending id " + canState.driveId);
-    robotsocket.emit("connectDrive", canState.driveId, (response) => {
-      console.log("RESPONSE:" + response);
-      if (response === "OK") {
-        setcanState((prev) => ({
-          ...prev,
-          driveState: "active",
-        }));
-      } else {
-        enqueueSnackbar("Drive didn't connect. Refreshing...", {
-          variant: "error",
-        });
-        requestCanInfo();
-      }
-    });
-  }
-  function disconnectDrive() {
-    setcanState((prev) => ({
-      ...prev,
-      driveState: "connecting",
-    }));
-    console.log("Disconnecting drive");
-    robotsocket.emit("disconnectDrive", (response) => {
-      console.log("RESPONSE:" + response);
-      if (response === "OK") {
-        setcanState((prev) => ({
-          ...prev,
-          driveState: "idle",
-        }));
-      } else {
-        enqueueSnackbar("Drive didn't disconnect. Refreshing...", {
-          variant: "error",
-        });
-        requestCanInfo();
-      }
-    });
-  }
-
-  function connectArm() {
-    setcanState((prev) => ({
-      ...prev,
-      armState: "connecting",
-    }));
-    console.log("Connecting Arm, Sending id " + canState.armId);
-    robotsocket.emit("connectArm", canState.armId, (response) => {
-      console.log("RESPONSE:" + response);
-      if (response === "OK") {
-        setcanState((prev) => ({
-          ...prev,
-          armState: "active",
-        }));
-      } else {
-        enqueueSnackbar("Arm didn't connect. Refreshing...", {
-          variant: "error",
-        });
-        requestCanInfo();
-      }
-    });
-  }
-  function disconnectArm() {
-    setcanState((prev) => ({
-      ...prev,
-      armState: "connecting",
-    }));
-    console.log("Disconnecting Arm");
-    robotsocket.emit("disconnectArm", (response) => {
-      console.log("RESPONSE:" + response);
-      if (response === "OK") {
-        setcanState((prev) => ({
-          ...prev,
-          armState: "idle",
-        }));
-      } else {
-        enqueueSnackbar("Arm didn't disconnect. Refreshing...", {
-          variant: "error",
-        });
-        requestCanInfo();
-      }
-    });
-  }
-
-  function connectScience() {
-    setcanState((prev) => ({
-      ...prev,
-      scienceState: "connecting",
-    }));
-    console.log("Connecting Science, Sending id " + canState.scienceId);
-    robotsocket.emit("connectScience", canState.scienceId, (response) => {
-      console.log("RESPONSE:" + response);
-      if (response === "OK") {
-        setcanState((prev) => ({
-          ...prev,
-          scienceState: "active",
-        }));
-      } else {
-        enqueueSnackbar("Science didn't connect. Refreshing...", {
-          variant: "error",
-        });
-        requestCanInfo();
-      }
-    });
-  }
-  function disconnectScience() {
-    setcanState((prev) => ({
-      ...prev,
-      scienceState: "connecting",
-    }));
-    console.log("Disconnecting Science");
-    robotsocket.emit("disconnectScience", (response) => {
-      console.log("RESPONSE:" + response);
-      if (response === "OK") {
-        setcanState((prev) => ({
-          ...prev,
-          scienceState: "idle",
-        }));
-      } else {
-        enqueueSnackbar("Science didn't disconnect. Refreshing...", {
-          variant: "error",
-        });
-        requestCanInfo();
-      }
-    });
-  }
-
-  function connectGPS() {
-    setcanState((prev) => ({
-      ...prev,
-      gpsState: "connecting",
-    }));
-    console.log("Connecting GPS, Sending id " + canState.gpsId);
-    robotsocket.emit("connectGPS", canState.gpsId, (response) => {
-      console.log("RESPONSE:" + response);
-      if (response === "OK") {
-        setcanState((prev) => ({
-          ...prev,
-          gpsState: "active",
-        }));
-      } else {
-        enqueueSnackbar("GPS didn't connect. Refreshing...", {
-          variant: "error",
-        });
-        requestCanInfo();
-      }
-    });
-  }
-  function disconnectGPS() {
-    setcanState((prev) => ({
-      ...prev,
-      gpsState: "connecting",
-    }));
-    console.log("Disconnecting GPS");
-    robotsocket.emit("disconnectGPS", (response) => {
-      console.log("RESPONSE:" + response);
-      if (response === "OK") {
-        setcanState((prev) => ({
-          ...prev,
-          gpsState: "idle",
-        }));
-      } else {
-        enqueueSnackbar(
-          "GPS didn't disconnect, auto-updating to current state",
-          { variant: "error" },
-        );
-        requestCanInfo();
-      }
-    });
-  }
-  function disconnectAll() {
-    if (canState.driveState != "idle") {
-      disconnectDrive();
-    }
-    if (canState.armState != "idle") {
-      disconnectArm();
-    }
-    if (canState.scienceState != "idle") {
-      disconnectScience();
-    }
-    if (canState.gpsState != "idle") {
-      disconnectGPS();
-    }
-    console.log("ALL have been disconnected.");
-  }
 
   useEffect(() => {
     if (openPane == "Backend") {

--- a/src/components/socket.io/PeripheralManager.jsx
+++ b/src/components/socket.io/PeripheralManager.jsx
@@ -9,6 +9,7 @@ import Select from "@mui/material/Select";
 import ElectricalServicesIcon from "@mui/icons-material/ElectricalServices";
 import EjectIcon from "@mui/icons-material/Eject";
 import { usePeripherals } from "../../contexts/PeripheralContext";
+import { useSerial } from "../../contexts/SerialContext";
 
 export default function PeripheralManager({ openPane }) {
   const {
@@ -17,17 +18,15 @@ export default function PeripheralManager({ openPane }) {
     setcanState,
     connectDrive,
     disconnectDrive,
-    connectArm, 
-    disconnectArm, 
-    connectScience, 
+    connectArm,
+    disconnectArm,
+    connectScience,
     disconnectScience,
-    connectGPS, 
-    disconnectGPS, 
-    disconnectAll, 
-    serialState
+    connectGPS,
+    disconnectGPS,
+    disconnectAll,
   } = usePeripherals();
-
-
+  const { serialState } = useSerial();
 
   useEffect(() => {
     if (openPane == "Backend") {

--- a/src/components/socket.io/PeripheralManager.jsx
+++ b/src/components/socket.io/PeripheralManager.jsx
@@ -26,11 +26,12 @@ export default function PeripheralManager({ openPane }) {
     disconnectGPS,
     disconnectAll,
   } = usePeripherals();
-  const { serialState } = useSerial();
+  const { serialState, refresh } = useSerial();
 
   useEffect(() => {
     if (openPane == "Backend") {
       requestCanInfo(); // autoload can serialState
+      refresh() // update serial
     } else {
       setcanState((prev) => ({
         ...prev,

--- a/src/contexts/PeripheralContext.jsx
+++ b/src/contexts/PeripheralContext.jsx
@@ -1,0 +1,13 @@
+import { createContext, useContext } from "react";
+
+export const PeripheralContext = createContext(null);
+
+export function usePeripherals() {
+  const context = useContext(PeripheralContext);
+
+  if (!context) {
+    throw new Error("usePeripherals must be used inside PeripheralProvider");
+  }
+
+  return context;
+}

--- a/src/contexts/SerialContext.jsx
+++ b/src/contexts/SerialContext.jsx
@@ -6,7 +6,7 @@ export function useSerial() {
   const context = useContext(SerialContext);
 
   if (!context) {
-    throw new Error("usePeripherals must be used inside SerialProvider");
+    throw new Error("SerialContext must be used inside SerialProvider");
   }
 
   return context;

--- a/src/contexts/SerialContext.jsx
+++ b/src/contexts/SerialContext.jsx
@@ -1,0 +1,13 @@
+import { createContext, useContext } from "react";
+
+export const SerialContext = createContext(null);
+
+export function useSerial() {
+  const context = useContext(SerialContext);
+
+  if (!context) {
+    throw new Error("usePeripherals must be used inside SerialProvider");
+  }
+
+  return context;
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -13,6 +13,7 @@ import ArmView from "./views/ArmView";
 import ScienceView from "./views/ScienceView";
 import AutonomyView from "./views/AutonomyView";
 import ExtrasView from "./views/ExtrasView";
+import SerialConsole from "./components/serial/SerialConsole";
 // extras panes
 import { Graphs, Files, SpeedTestView } from "./views/ExtrasView";
 
@@ -65,6 +66,10 @@ const approuter = createBrowserRouter([
           {
             path: "speedtest",
             element: <SpeedTestView />,
+          },
+          {
+            path: "serial",
+            element: <SerialConsole />,
           },
         ],
       },

--- a/src/providers/PeripheralProvider.jsx
+++ b/src/providers/PeripheralProvider.jsx
@@ -8,14 +8,16 @@ export const PeripheralProvider = ({ children }) => {
 
   useEffect(() => {
     // when one client updates data, other clients get asked to refresh data
-    const processupdate = () => {
-       console.log("Server CAN changed, force updating");
+    const updateCan = () => {
+       console.log("Refreshing CAN state");
        requestCanInfo()
     };
-    robotsocket.on("forcecanrefresh", processupdate);
+    robotsocket.on("forcecanrefresh", updateCan);
+    robotsocket.on("connect", updateCan);
 
     return () => {
-    robotsocket.off("forcecanrefresh", processupdate);
+    robotsocket.off("forcecanrefresh", updateCan);
+    robotsocket.off("connect", updateCan);
     };
   }, []);
 

--- a/src/providers/PeripheralProvider.jsx
+++ b/src/providers/PeripheralProvider.jsx
@@ -1,10 +1,12 @@
-import { useCallback, useMemo, useState } from "react";
+import { useState } from "react";
 import { useSnackbar } from "notistack";
 import { robotsocket } from "../components/socket.io/socket";
 import { PeripheralContext } from "../contexts/PeripheralContext";
 
 
 export const PeripheralProvider = ({ children }) => {
+
+    const { enqueueSnackbar } = useSnackbar();
 
   const [canState, setcanState] = useState({
     driveState: "idle", // idle, connecting, active

--- a/src/providers/PeripheralProvider.jsx
+++ b/src/providers/PeripheralProvider.jsx
@@ -1,0 +1,258 @@
+import { useCallback, useMemo, useState } from "react";
+import { useSnackbar } from "notistack";
+import { robotsocket } from "../components/socket.io/socket";
+import { PeripheralContext } from "../contexts/PeripheralContext";
+
+
+export const PeripheralProvider = ({ children }) => {
+
+  const [canState, setcanState] = useState({
+    driveState: "idle", // idle, connecting, active
+    armState: "idle", // idle, connecting, active
+    scienceState: "idle", // idle, connecting, active
+    gpsState: "idle", // idle, connecting, active
+    uartMode: "???", // ???, CAN, UART
+    loading: true, // lock buttons, dropdowns when refreshing can data
+    canIds: [], // array with every possible serial device
+    driveId: "disconnect", // selected can id in dropdown or disconnect
+    armId: "disconnect", // selected can id in dropdown or disconnect
+    scienceId: "disconnect", // selected can id in dropdown or disconnect
+    gpsId: "disconnect", // selected can id in dropdown or disconnect
+  });
+
+  function requestCanInfo() {
+    // lock the ui so user can't do anything while loading
+    setcanState((prev) => ({
+      ...prev,
+      loading: true,
+    }));
+    robotsocket.emit("getCanInfo", (data) => {
+      //console.log(data);
+      setcanState((prev) => ({
+        ...prev,
+        canIds: data["canIds"],
+        driveId: data["driveId"],
+        armId: data["armId"],
+        scienceId: data["scienceId"],
+        gpsId: data["gpsId"],
+        uartMode: data["uartMode"],
+        // assignment if connected or not by text
+        driveState: data["driveId"] !== "disconnect" ? "active" : "idle",
+        armState: data["armId"] !== "disconnect" ? "active" : "idle",
+        scienceState: data["scienceId"] !== "disconnect" ? "active" : "idle",
+        gpsState: data["gpsId"] !== "disconnect" ? "active" : "idle",
+        loading: false,
+      }));
+    });
+  }
+
+  function connectDrive() {
+    setcanState((prev) => ({
+      ...prev,
+      driveState: "connecting",
+    }));
+    console.log("Connecting Drive, Sending id " + canState.driveId);
+    robotsocket.emit("connectDrive", canState.driveId, (response) => {
+      console.log("RESPONSE:" + response);
+      if (response === "OK") {
+        setcanState((prev) => ({
+          ...prev,
+          driveState: "active",
+        }));
+      } else {
+        enqueueSnackbar("Drive didn't connect. Refreshing...", {
+          variant: "error",
+        });
+        requestCanInfo();
+      }
+    });
+  }
+  function disconnectDrive() {
+    setcanState((prev) => ({
+      ...prev,
+      driveState: "connecting",
+    }));
+    console.log("Disconnecting drive");
+    robotsocket.emit("disconnectDrive", (response) => {
+      console.log("RESPONSE:" + response);
+      if (response === "OK") {
+        setcanState((prev) => ({
+          ...prev,
+          driveState: "idle",
+        }));
+      } else {
+        enqueueSnackbar("Drive didn't disconnect. Refreshing...", {
+          variant: "error",
+        });
+        requestCanInfo();
+      }
+    });
+  }
+
+  function connectArm() {
+    setcanState((prev) => ({
+      ...prev,
+      armState: "connecting",
+    }));
+    console.log("Connecting Arm, Sending id " + canState.armId);
+    robotsocket.emit("connectArm", canState.armId, (response) => {
+      console.log("RESPONSE:" + response);
+      if (response === "OK") {
+        setcanState((prev) => ({
+          ...prev,
+          armState: "active",
+        }));
+      } else {
+        enqueueSnackbar("Arm didn't connect. Refreshing...", {
+          variant: "error",
+        });
+        requestCanInfo();
+      }
+    });
+  }
+  function disconnectArm() {
+    setcanState((prev) => ({
+      ...prev,
+      armState: "connecting",
+    }));
+    console.log("Disconnecting Arm");
+    robotsocket.emit("disconnectArm", (response) => {
+      console.log("RESPONSE:" + response);
+      if (response === "OK") {
+        setcanState((prev) => ({
+          ...prev,
+          armState: "idle",
+        }));
+      } else {
+        enqueueSnackbar("Arm didn't disconnect. Refreshing...", {
+          variant: "error",
+        });
+        requestCanInfo();
+      }
+    });
+  }
+
+  function connectScience() {
+    setcanState((prev) => ({
+      ...prev,
+      scienceState: "connecting",
+    }));
+    console.log("Connecting Science, Sending id " + canState.scienceId);
+    robotsocket.emit("connectScience", canState.scienceId, (response) => {
+      console.log("RESPONSE:" + response);
+      if (response === "OK") {
+        setcanState((prev) => ({
+          ...prev,
+          scienceState: "active",
+        }));
+      } else {
+        enqueueSnackbar("Science didn't connect. Refreshing...", {
+          variant: "error",
+        });
+        requestCanInfo();
+      }
+    });
+  }
+  function disconnectScience() {
+    setcanState((prev) => ({
+      ...prev,
+      scienceState: "connecting",
+    }));
+    console.log("Disconnecting Science");
+    robotsocket.emit("disconnectScience", (response) => {
+      console.log("RESPONSE:" + response);
+      if (response === "OK") {
+        setcanState((prev) => ({
+          ...prev,
+          scienceState: "idle",
+        }));
+      } else {
+        enqueueSnackbar("Science didn't disconnect. Refreshing...", {
+          variant: "error",
+        });
+        requestCanInfo();
+      }
+    });
+  }
+
+  function connectGPS() {
+    setcanState((prev) => ({
+      ...prev,
+      gpsState: "connecting",
+    }));
+    console.log("Connecting GPS, Sending id " + canState.gpsId);
+    robotsocket.emit("connectGPS", canState.gpsId, (response) => {
+      console.log("RESPONSE:" + response);
+      if (response === "OK") {
+        setcanState((prev) => ({
+          ...prev,
+          gpsState: "active",
+        }));
+      } else {
+        enqueueSnackbar("GPS didn't connect. Refreshing...", {
+          variant: "error",
+        });
+        requestCanInfo();
+      }
+    });
+  }
+  function disconnectGPS() {
+    setcanState((prev) => ({
+      ...prev,
+      gpsState: "connecting",
+    }));
+    console.log("Disconnecting GPS");
+    robotsocket.emit("disconnectGPS", (response) => {
+      console.log("RESPONSE:" + response);
+      if (response === "OK") {
+        setcanState((prev) => ({
+          ...prev,
+          gpsState: "idle",
+        }));
+      } else {
+        enqueueSnackbar(
+          "GPS didn't disconnect, auto-updating to current state",
+          { variant: "error" },
+        );
+        requestCanInfo();
+      }
+    });
+  }
+  function disconnectAll() {
+    if (canState.driveState != "idle") {
+      disconnectDrive();
+    }
+    if (canState.armState != "idle") {
+      disconnectArm();
+    }
+    if (canState.scienceState != "idle") {
+      disconnectScience();
+    }
+    if (canState.gpsState != "idle") {
+      disconnectGPS();
+    }
+    console.log("ALL have been disconnected.");
+  }
+
+    const value = {
+      canState,
+      requestCanInfo,
+      setcanState,
+      connectDrive,
+      disconnectDrive,
+      connectArm, 
+      disconnectArm, 
+      connectScience, 
+      disconnectScience,
+      connectGPS, 
+      disconnectGPS, 
+      disconnectAll
+    };
+
+  return (
+    <PeripheralContext.Provider value={value}>
+      {children}
+    </PeripheralContext.Provider>
+  );
+}
+export default PeripheralProvider;

--- a/src/providers/PeripheralProvider.jsx
+++ b/src/providers/PeripheralProvider.jsx
@@ -3,10 +3,8 @@ import { useSnackbar } from "notistack";
 import { robotsocket } from "../components/socket.io/socket";
 import { PeripheralContext } from "../contexts/PeripheralContext";
 
-
 export const PeripheralProvider = ({ children }) => {
-
-    const { enqueueSnackbar } = useSnackbar();
+  const { enqueueSnackbar } = useSnackbar();
 
   const [canState, setcanState] = useState({
     driveState: "idle", // idle, connecting, active
@@ -20,6 +18,15 @@ export const PeripheralProvider = ({ children }) => {
     armId: "disconnect", // selected can id in dropdown or disconnect
     scienceId: "disconnect", // selected can id in dropdown or disconnect
     gpsId: "disconnect", // selected can id in dropdown or disconnect
+  });
+
+    const [info, setInfo] = useState({
+    ports: [],
+    portId: "disconnect",
+    baudrate: 115200,
+    connected: false,
+    dtr: false,
+    rts: false,
   });
 
   function requestCanInfo() {
@@ -236,25 +243,27 @@ export const PeripheralProvider = ({ children }) => {
     console.log("ALL have been disconnected.");
   }
 
-    const value = {
-      canState,
-      requestCanInfo,
-      setcanState,
-      connectDrive,
-      disconnectDrive,
-      connectArm, 
-      disconnectArm, 
-      connectScience, 
-      disconnectScience,
-      connectGPS, 
-      disconnectGPS, 
-      disconnectAll
-    };
+  const value = {
+    canState,
+    requestCanInfo,
+    setcanState,
+    connectDrive,
+    disconnectDrive,
+    connectArm,
+    disconnectArm,
+    connectScience,
+    disconnectScience,
+    connectGPS,
+    disconnectGPS,
+    disconnectAll,
+    info,
+    setInfo
+  };
 
   return (
     <PeripheralContext.Provider value={value}>
       {children}
     </PeripheralContext.Provider>
   );
-}
+};
 export default PeripheralProvider;

--- a/src/providers/PeripheralProvider.jsx
+++ b/src/providers/PeripheralProvider.jsx
@@ -34,18 +34,6 @@ export const PeripheralProvider = ({ children }) => {
     scienceId: "disconnect", // selected can id in dropdown or disconnect
     gpsId: "disconnect", // selected can id in dropdown or disconnect
   });
-  const textEncoder = new TextEncoder();
-
-  function encodeBytes(bytes) {
-    let binary = "";
-    for (const byte of bytes) binary += String.fromCharCode(byte);
-    return btoa(binary);
-  }
-
-  function decodeBytes(encoded) {
-    const binary = atob(encoded);
-    return Uint8Array.from(binary, (character) => character.charCodeAt(0));
-  }
 
   function requestCanInfo() {
     // lock the ui so user can't do anything while loading

--- a/src/providers/PeripheralProvider.jsx
+++ b/src/providers/PeripheralProvider.jsx
@@ -20,7 +20,7 @@ export const PeripheralProvider = ({ children }) => {
     gpsId: "disconnect", // selected can id in dropdown or disconnect
   });
 
-    const [info, setInfo] = useState({
+    const [serialState, setserialState] = useState({
     ports: [],
     portId: "disconnect",
     baudrate: 115200,
@@ -256,8 +256,8 @@ export const PeripheralProvider = ({ children }) => {
     connectGPS,
     disconnectGPS,
     disconnectAll,
-    info,
-    setInfo
+    serialState,
+    setserialState
   };
 
   return (

--- a/src/providers/PeripheralProvider.jsx
+++ b/src/providers/PeripheralProvider.jsx
@@ -1,10 +1,23 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useSnackbar } from "notistack";
 import { robotsocket } from "../components/socket.io/socket";
 import { PeripheralContext } from "../contexts/PeripheralContext";
 
 export const PeripheralProvider = ({ children }) => {
   const { enqueueSnackbar } = useSnackbar();
+
+  useEffect(() => {
+    // when one client updates data, other clients get asked to refresh data
+    const processupdate = () => {
+       console.log("Server CAN changed, force updating");
+       requestCanInfo()
+    };
+    robotsocket.on("forcecanrefresh", processupdate);
+
+    return () => {
+    robotsocket.off("forcecanrefresh", processupdate);
+    };
+  }, []);
 
   const [canState, setcanState] = useState({
     driveState: "idle", // idle, connecting, active

--- a/src/providers/PeripheralProvider.jsx
+++ b/src/providers/PeripheralProvider.jsx
@@ -9,15 +9,15 @@ export const PeripheralProvider = ({ children }) => {
   useEffect(() => {
     // when one client updates data, other clients get asked to refresh data
     const updateCan = () => {
-       console.log("Refreshing CAN state");
-       requestCanInfo()
+      console.log("Refreshing CAN state");
+      requestCanInfo();
     };
     robotsocket.on("forcecanrefresh", updateCan);
     robotsocket.on("connect", updateCan);
 
     return () => {
-    robotsocket.off("forcecanrefresh", updateCan);
-    robotsocket.off("connect", updateCan);
+      robotsocket.off("forcecanrefresh", updateCan);
+      robotsocket.off("connect", updateCan);
     };
   }, []);
 
@@ -34,15 +34,18 @@ export const PeripheralProvider = ({ children }) => {
     scienceId: "disconnect", // selected can id in dropdown or disconnect
     gpsId: "disconnect", // selected can id in dropdown or disconnect
   });
+  const textEncoder = new TextEncoder();
 
-    const [serialState, setserialState] = useState({
-    ports: [],
-    portId: "disconnect",
-    baudrate: 115200,
-    connected: false,
-    dtr: false,
-    rts: false,
-  });
+  function encodeBytes(bytes) {
+    let binary = "";
+    for (const byte of bytes) binary += String.fromCharCode(byte);
+    return btoa(binary);
+  }
+
+  function decodeBytes(encoded) {
+    const binary = atob(encoded);
+    return Uint8Array.from(binary, (character) => character.charCodeAt(0));
+  }
 
   function requestCanInfo() {
     // lock the ui so user can't do anything while loading
@@ -271,8 +274,6 @@ export const PeripheralProvider = ({ children }) => {
     connectGPS,
     disconnectGPS,
     disconnectAll,
-    serialState,
-    setserialState
   };
 
   return (

--- a/src/providers/PeripheralProvider.jsx
+++ b/src/providers/PeripheralProvider.jsx
@@ -13,7 +13,7 @@ export const PeripheralProvider = ({ children }) => {
     armState: "idle", // idle, connecting, active
     scienceState: "idle", // idle, connecting, active
     gpsState: "idle", // idle, connecting, active
-    uartMode: "???", // ???, CAN, UART
+    uartMode: "CAN/UART", // CAN/UART (??? state), CAN, UART
     loading: true, // lock buttons, dropdowns when refreshing can data
     canIds: [], // array with every possible serial device
     driveId: "disconnect", // selected can id in dropdown or disconnect

--- a/src/providers/SerialProvider.jsx
+++ b/src/providers/SerialProvider.jsx
@@ -1,0 +1,185 @@
+import { useState, useEffect, useRef, useCallback } from "react";
+import { robotsocket } from "../components/socket.io/socket";
+import { SerialContext } from "../contexts/SerialContext";
+
+export const SerialProvider = ({ children }) => {
+  const decoderRef = useRef(new TextDecoder());
+  const outputRef = useRef(null);
+
+  const [serialState, setserialState] = useState({
+    ports: [],
+    portId: "disconnect",
+    baudrate: 115200,
+    connected: false,
+    dtr: false,
+    rts: false,
+  });
+
+  const [selectedPort, setSelectedPort] = useState("disconnect");
+  const [baudrate, setBaudrate] = useState(115200);
+  const [input, setInput] = useState("");
+  const [output, setOutput] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+  const [dtr, setDtr] = useState(false);
+  const [rts, setRts] = useState(false);
+  const [appendCarriageReturn, setAppendCarriageReturn] = useState(false);
+  const [appendNewline, setAppendNewline] = useState(true);
+  const [localEcho, setLocalEcho] = useState(false);
+  const [autoScroll, setAutoScroll] = useState(true);
+
+  function applyInfo(nextInfo) {
+    setserialState(nextInfo);
+    setSelectedPort(nextInfo.portId);
+    setBaudrate(nextInfo.baudrate);
+    setDtr(nextInfo.dtr ?? false);
+    setRts(nextInfo.rts ?? false);
+  }
+
+  const refresh = useCallback(() => {
+    robotsocket.emit("getSerialConsoleInfo", (response) => {
+      if (response) applyInfo(response);
+    });
+  }, []);
+
+  useEffect(() => {
+    const handleData = ({ data }) => {
+      const text = decoderRef.current.decode(decodeBytes(data), {
+        stream: true,
+      });
+      setOutput((previous) => (previous + text).slice(-100_000));
+    };
+    const handleStatus = (status) => applyInfo(status);
+    const handleError = ({ message }) => setError(message);
+
+    robotsocket.on("serialConsoleData", handleData);
+    robotsocket.on("serialConsoleStatus", handleStatus);
+    robotsocket.on("serialConsoleError", handleError);
+    refresh();
+
+    return () => {
+      robotsocket.off("serialConsoleData", handleData);
+      robotsocket.off("serialConsoleStatus", handleStatus);
+      robotsocket.off("serialConsoleError", handleError);
+    };
+  }, [refresh]);
+
+  useEffect(() => {
+    if (autoScroll && outputRef.current) {
+      outputRef.current.scrollTop = outputRef.current.scrollHeight;
+    }
+  }, [output, autoScroll]);
+
+  function openConsole() {
+    setBusy(true);
+    setError("");
+    robotsocket.emit(
+      "openSerialConsole",
+      { portId: selectedPort, baudrate: Number(baudrate) },
+      (response) => {
+        setBusy(false);
+        if (response?.status !== "OK") {
+          setError(response?.message || "Unable to open serial console");
+        } else {
+          refresh();
+        }
+      },
+    );
+  }
+
+  function closeConsole() {
+    setBusy(true);
+    robotsocket.emit("closeSerialConsole", (response) => {
+      setBusy(false);
+      if (response?.status !== "OK") {
+        setError(response?.message || "Unable to close serial console");
+      }
+    });
+  }
+
+  function sendInput() {
+    if (!input) return;
+    const ending = `${appendCarriageReturn ? "\r" : ""}${appendNewline ? "\n" : ""}`;
+    const payload = textEncoder.encode(`${input}${ending}`);
+    robotsocket.emit(
+      "writeSerialConsole",
+      { data: encodeBytes(payload) },
+      (response) => {
+        if (response?.status !== "OK") {
+          setError(response?.message || "Serial write failed");
+        }
+      },
+    );
+    if (localEcho) {
+      setOutput((previous) => (previous + input + ending).slice(-100_000));
+    }
+    setInput("");
+  }
+
+  function updateRts(enabled) {
+    robotsocket.emit("setSerialConsoleRts", { enabled }, (response) => {
+      if (response?.status === "OK") {
+        setRts(enabled);
+      } else {
+        setError(response?.message || "Unable to set RTS");
+      }
+    });
+  }
+
+  function updateDtr(enabled) {
+    robotsocket.emit("setSerialConsoleDtr", { enabled }, (response) => {
+      if (response?.status === "OK") {
+        setDtr(enabled);
+      } else {
+        setError(response?.message || "Unable to set DTR");
+      }
+    });
+  }
+
+  function pulseDtr() {
+    robotsocket.emit(
+      "pulseSerialConsoleDtr",
+      { durationMs: 200 },
+      (response) => {
+        if (response?.status === "OK") {
+          setDtr(true);
+        } else {
+          setError(response?.message || "Unable to pulse DTR");
+        }
+      },
+    );
+  }
+
+  const value = {
+    pulseDtr,
+    updateDtr,
+    updateRts,
+    sendInput,
+    closeConsole,
+    openConsole,
+    serialState,
+    selectedPort,
+    refresh,
+    autoScroll,
+    outputRef,
+    setAppendNewline,
+    baudrate,
+    output,
+    input,
+    appendCarriageReturn,
+    appendNewline,
+    localEcho,
+    setLocalEcho,
+    setAutoScroll,
+    setAppendCarriageReturn,
+    busy,
+    error,
+    dtr,
+    rts,
+  };
+
+  return (
+    <SerialContext.Provider value={value}>{children}</SerialContext.Provider>
+  );
+};
+export default SerialProvider;

--- a/src/providers/SerialProvider.jsx
+++ b/src/providers/SerialProvider.jsx
@@ -99,11 +99,16 @@ export const SerialProvider = ({ children }) => {
   }, [output, autoScroll]);
 
   function openConsole() {
+    const parsedBaudrate = Number(baudrate);
+    if (!Number.isInteger(parsedBaudrate) || parsedBaudrate <= 0) {
+      setError("Enter a positive baud rate");
+      return;
+    }
     setBusy(true);
     setError("");
     robotsocket.emit(
       "openSerialConsole",
-      { portId: selectedPort, baudrate: Number(baudrate) },
+      { portId: selectedPort, baudrate: parsedBaudrate },
       (response) => {
         setBusy(false);
         if (response?.status !== "OK") {
@@ -170,7 +175,7 @@ export const SerialProvider = ({ children }) => {
       { durationMs: 200 },
       (response) => {
         if (response?.status === "OK") {
-          setDtr(true);
+          setDtr(false);
         } else {
           setError(response?.message || "Unable to pulse DTR");
         }
@@ -192,6 +197,8 @@ export const SerialProvider = ({ children }) => {
     setAppendCarriageReturn,
     setSelectedPort,
     setError,
+    setInput,
+    setOutput,
     setBaudrate,
     serialState,
     selectedPort,

--- a/src/providers/SerialProvider.jsx
+++ b/src/providers/SerialProvider.jsx
@@ -36,6 +36,34 @@ export const SerialProvider = ({ children }) => {
     setRts(nextInfo.rts ?? false);
   }
 
+  const textEncoder = new TextEncoder();
+
+  function encodeBytes(bytes) {
+    let binary = "";
+    for (const byte of bytes) binary += String.fromCharCode(byte);
+    return btoa(binary);
+  }
+
+  function decodeBytes(encoded) {
+    const binary = atob(encoded);
+    return Uint8Array.from(binary, (character) => character.charCodeAt(0));
+  }
+
+  useEffect(() => {
+    // when one client updates data, other clients get asked to refresh data
+    const updateSerial = () => {
+      console.log("Refreshing CAN state");
+      refresh();
+    };
+    robotsocket.on("forcecanrefresh", updateSerial);
+    robotsocket.on("connect", updateSerial);
+
+    return () => {
+      robotsocket.off("forcecanrefresh", updateSerial);
+      robotsocket.off("connect", updateSerial);
+    };
+  }, []);
+
   const refresh = useCallback(() => {
     robotsocket.emit("getSerialConsoleInfo", (response) => {
       if (response) applyInfo(response);
@@ -157,21 +185,24 @@ export const SerialProvider = ({ children }) => {
     sendInput,
     closeConsole,
     openConsole,
+    refresh,
+    setAppendNewline,
+    setLocalEcho,
+    setAutoScroll,
+    setAppendCarriageReturn,
+    setSelectedPort,
+    setError,
+    setBaudrate,
     serialState,
     selectedPort,
-    refresh,
     autoScroll,
     outputRef,
-    setAppendNewline,
     baudrate,
     output,
     input,
     appendCarriageReturn,
     appendNewline,
     localEcho,
-    setLocalEcho,
-    setAutoScroll,
-    setAppendCarriageReturn,
     busy,
     error,
     dtr,

--- a/src/views/App.jsx
+++ b/src/views/App.jsx
@@ -19,6 +19,7 @@ import GamepadProvider from "../providers/GamepadProvider";
 import AutonomyModeProvider from "../providers/AutonomyModeProvider";
 import PeripheralProvider from "../providers/PeripheralProvider";
 import { SnackbarProvider, useSnackbar } from "notistack";
+import SerialProvider from "../providers/SerialProvider";
 
 function App() {
   // Global autonomy state so every view can react to it
@@ -107,58 +108,60 @@ function App() {
     >
       {/* snackbar */}
       <SnackbarProvider maxSnack={5}>
-        <PeripheralProvider>
-          <AutonomyModeProvider
-            autonomyEnabled={autonomyEnabled}
-            setAutonomyEnabled={setAutonomyEnabled}
-          >
-            <ArmCommandProvider
-              armCommands={armCommands}
-              setArmCommands={setArmCommands}
+        <SerialProvider>
+          <PeripheralProvider>
+            <AutonomyModeProvider
+              autonomyEnabled={autonomyEnabled}
+              setAutonomyEnabled={setAutonomyEnabled}
             >
-              <GamepadProvider
-                connectedGamepads={connectedGamepads}
-                setConnectedGamepads={setConnectedGamepads}
+              <ArmCommandProvider
+                armCommands={armCommands}
+                setArmCommands={setArmCommands}
               >
-                <DriveCommandProvider
-                  driveCommands={driveCommands}
-                  setDriveCommands={setDriveCommands}
+                <GamepadProvider
+                  connectedGamepads={connectedGamepads}
+                  setConnectedGamepads={setConnectedGamepads}
                 >
-                  <MastCommandProvider
-                    mastCommands={mastCommands}
-                    setMastCommands={setMastCommands}
+                  <DriveCommandProvider
+                    driveCommands={driveCommands}
+                    setDriveCommands={setDriveCommands}
                   >
-                    <CssBaseline />
-                    {/* Normalizes styles */}
-                    <TopAppBar
-                      selectedElements={selectedElements}
-                      setSelectedElements={setSelectedElements}
-                      addSnackbarMessage={addSnackbarMessage}
-                    />
-
-                    <Box
-                      component="main"
-                      sx={{
-                        flexGrow: 1,
-                        p: 2,
-                        display: "flex",
-                        flexDirection: "column",
-                        overflow: "hidden",
-                        minHeight: 0,
-                        marginTop: "60px",
-                      }}
+                    <MastCommandProvider
+                      mastCommands={mastCommands}
+                      setMastCommands={setMastCommands}
                     >
-                      <SplitView selectedElements={selectedElements}>
-                        {/* we pass all these elements as "children" into SplitView */}
-                        <Outlet />
-                      </SplitView>
-                    </Box>
-                  </MastCommandProvider>
-                </DriveCommandProvider>
-              </GamepadProvider>
-            </ArmCommandProvider>
-          </AutonomyModeProvider>
-        </PeripheralProvider>
+                      <CssBaseline />
+                      {/* Normalizes styles */}
+                      <TopAppBar
+                        selectedElements={selectedElements}
+                        setSelectedElements={setSelectedElements}
+                        addSnackbarMessage={addSnackbarMessage}
+                      />
+
+                      <Box
+                        component="main"
+                        sx={{
+                          flexGrow: 1,
+                          p: 2,
+                          display: "flex",
+                          flexDirection: "column",
+                          overflow: "hidden",
+                          minHeight: 0,
+                          marginTop: "60px",
+                        }}
+                      >
+                        <SplitView selectedElements={selectedElements}>
+                          {/* we pass all these elements as "children" into SplitView */}
+                          <Outlet />
+                        </SplitView>
+                      </Box>
+                    </MastCommandProvider>
+                  </DriveCommandProvider>
+                </GamepadProvider>
+              </ArmCommandProvider>
+            </AutonomyModeProvider>
+          </PeripheralProvider>
+        </SerialProvider>
       </SnackbarProvider>
     </Box>
   );

--- a/src/views/App.jsx
+++ b/src/views/App.jsx
@@ -17,6 +17,7 @@ import DriveCommandProvider from "../providers/DriveCommandProvider";
 import MastCommandProvider from "../providers/MastCommandProvider";
 import GamepadProvider from "../providers/GamepadProvider";
 import AutonomyModeProvider from "../providers/AutonomyModeProvider";
+import PeripheralProvider from "../providers/PeripheralProvider";
 import { SnackbarProvider, useSnackbar } from "notistack";
 
 function App() {
@@ -106,56 +107,58 @@ function App() {
     >
       {/* snackbar */}
       <SnackbarProvider maxSnack={5}>
-        <AutonomyModeProvider
-          autonomyEnabled={autonomyEnabled}
-          setAutonomyEnabled={setAutonomyEnabled}
-        >
-          <ArmCommandProvider
-            armCommands={armCommands}
-            setArmCommands={setArmCommands}
+        <PeripheralProvider>
+          <AutonomyModeProvider
+            autonomyEnabled={autonomyEnabled}
+            setAutonomyEnabled={setAutonomyEnabled}
           >
-            <GamepadProvider
-              connectedGamepads={connectedGamepads}
-              setConnectedGamepads={setConnectedGamepads}
+            <ArmCommandProvider
+              armCommands={armCommands}
+              setArmCommands={setArmCommands}
             >
-              <DriveCommandProvider
-                driveCommands={driveCommands}
-                setDriveCommands={setDriveCommands}
+              <GamepadProvider
+                connectedGamepads={connectedGamepads}
+                setConnectedGamepads={setConnectedGamepads}
               >
-                <MastCommandProvider
-                  mastCommands={mastCommands}
-                  setMastCommands={setMastCommands}
+                <DriveCommandProvider
+                  driveCommands={driveCommands}
+                  setDriveCommands={setDriveCommands}
                 >
-                  <CssBaseline />
-                  {/* Normalizes styles */}
-                  <TopAppBar
-                    selectedElements={selectedElements}
-                    setSelectedElements={setSelectedElements}
-                    addSnackbarMessage={addSnackbarMessage}
-                  />
-
-                  <Box
-                    component="main"
-                    sx={{
-                      flexGrow: 1,
-                      p: 2,
-                      display: "flex",
-                      flexDirection: "column",
-                      overflow: "hidden",
-                      minHeight: 0,
-                      marginTop: "60px",
-                    }}
+                  <MastCommandProvider
+                    mastCommands={mastCommands}
+                    setMastCommands={setMastCommands}
                   >
-                    <SplitView selectedElements={selectedElements}>
-                      {/* we pass all these elements as "children" into SplitView */}
-                      <Outlet />
-                    </SplitView>
-                  </Box>
-                </MastCommandProvider>
-              </DriveCommandProvider>
-            </GamepadProvider>
-          </ArmCommandProvider>
-        </AutonomyModeProvider>
+                    <CssBaseline />
+                    {/* Normalizes styles */}
+                    <TopAppBar
+                      selectedElements={selectedElements}
+                      setSelectedElements={setSelectedElements}
+                      addSnackbarMessage={addSnackbarMessage}
+                    />
+
+                    <Box
+                      component="main"
+                      sx={{
+                        flexGrow: 1,
+                        p: 2,
+                        display: "flex",
+                        flexDirection: "column",
+                        overflow: "hidden",
+                        minHeight: 0,
+                        marginTop: "60px",
+                      }}
+                    >
+                      <SplitView selectedElements={selectedElements}>
+                        {/* we pass all these elements as "children" into SplitView */}
+                        <Outlet />
+                      </SplitView>
+                    </Box>
+                  </MastCommandProvider>
+                </DriveCommandProvider>
+              </GamepadProvider>
+            </ArmCommandProvider>
+          </AutonomyModeProvider>
+        </PeripheralProvider>
       </SnackbarProvider>
     </Box>
   );

--- a/src/views/ArmView.jsx
+++ b/src/views/ArmView.jsx
@@ -12,6 +12,7 @@ import {
 import { useArmCommands } from "../contexts/ArmCommandContext";
 import { useConnectedGamepads } from "../contexts/GamepadContext";
 import { useAutonomyMode } from "../contexts/AutonomyModeContext";
+import { usePeripherals } from "../contexts/PeripheralContext";
 
 import {
   ARM_JOINT_KEYS,
@@ -33,6 +34,8 @@ function valuesDiffer(a, b, epsilon = 0.01) {
 // Handles manual sliders, gamepad-driven display, feedback, TX status,
 // and autonomy lockout.
 export default function ArmView() {
+
+  const { canState } = usePeripherals();
   const [armCommands, setArmCommands] = useArmCommands();
   const [connectedGamepads] = useConnectedGamepads();
   const serverConnected = useRobotSocketStatus();
@@ -305,6 +308,18 @@ export default function ArmView() {
         >
           Arm · {controlModeLabel} · {sendModeLabel}
         </Typography>
+
+        {(canState.armState == "idle"&& !controlsLocked) && (
+          <Typography
+            sx={{
+              textAlign: "center",
+              fontWeight: 700,
+            }}
+            color="error"
+          >
+            You don't have CAN connected!
+          </Typography>
+        )}
 
         {controlsLocked && (
           <Typography

--- a/src/views/DriveView.jsx
+++ b/src/views/DriveView.jsx
@@ -28,7 +28,7 @@ export default function DriveComponents() {
             }}
             color="error"
           >
-            You don't have CAN/UART connected!
+            You don't have {canState.uartMode} connected!
           </Typography>
         )}
         {controlsLocked && (

--- a/src/views/DriveView.jsx
+++ b/src/views/DriveView.jsx
@@ -3,8 +3,10 @@ import DriveManualInput from "../components/gamepad/DriveWidget";
 import { useRef } from "react";
 import { Typography } from "@mui/material";
 import { useAutonomyMode } from "../contexts/AutonomyModeContext";
+import { usePeripherals } from "../contexts/PeripheralContext";
 
 export default function DriveComponents() {
+  const { canState } = usePeripherals();
   const containerRef = useRef(null);
 
   // Read global autonomy state
@@ -18,6 +20,17 @@ export default function DriveComponents() {
       style={{ userSelect: "none" }}
     >
       <div className="flex-1 flex flex-col gap-2 p-2 min-h-0">
+        {(canState.driveState == "idle" && !controlsLocked) && (
+          <Typography
+            sx={{
+              textAlign: "center",
+              fontWeight: 700,
+            }}
+            color="error"
+          >
+            You don't have CAN/UART connected!
+          </Typography>
+        )}
         {controlsLocked && (
           <Typography
             sx={{

--- a/src/views/ExtrasView.jsx
+++ b/src/views/ExtrasView.jsx
@@ -40,6 +40,15 @@ export default function ExtrasView() {
         >
           SpeedTest
         </Button>
+
+        <Button
+          style={{ marginRight: 5, marginLeft: 5 }}
+          component={Link}
+          to="serial"
+          variant="contained"
+        >
+          Serial Console
+        </Button>
       </div>
 
       <div className="flex-1 flex flex-col min-h-0">

--- a/src/views/ScienceView.jsx
+++ b/src/views/ScienceView.jsx
@@ -4,8 +4,11 @@ import Tabs from "@mui/material/Tabs";
 import Tab from "@mui/material/Tab";
 import { useAutonomyMode } from "../contexts/AutonomyModeContext";
 import ScienceGraphTable from "../components/science/ScienceGraphTable";
+import { usePeripherals } from "../contexts/PeripheralContext";
 
 export default function ScienceView() {
+  const { canState } = usePeripherals();
+
   const [tabContent, setTabContent] = useState(0);
 
   // Read global autonomy state
@@ -40,6 +43,17 @@ const exampleSteps = [
       className="flex flex-1 flex-col overflow-auto h-full min-h-0"
       style={{ userSelect: "none" }}
     >
+    {(canState.scienceState == "idle"&& !controlsLocked) && (
+          <Typography
+            sx={{
+              textAlign: "center",
+              fontWeight: 700,
+            }}
+            color="error"
+          >
+            You don't have CAN connected!
+          </Typography>
+        )}
       {controlsLocked && (
         <Typography
           color="error"

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -10,6 +10,7 @@ const routes = [
   "/extras/graphs",
   "/extras/files",
   "/extras/speedtest",
+  "/extras/serial"
 ];
 
 for (const route of routes) {


### PR DESCRIPTION
- Move all CAN/UART connection logic into a context
- Implemented Serial console so we can remotely DTR the firmware team boards over serial
- Serial context ensures CAN/Serial devices can't be connected to twice
- Added warning on all panes (drive, arm, science) when the respective CAN/UART connection isn't connected for operator visibility
- Every time a change happens to the CAN devices, all other clients are now asked to refresh their data
- On connection data is auto-refreshed

<details>
<summary>Screenshots</summary>  

### Drive CAN/UART Warning  
<img width="514" height="223" alt="Screenshot 2026-08-18 at 12 13 26 PM" src="https://github.com/user-attachments/assets/d76b379e-cab2-4ec6-90dd-4c2925386e27" />
  
### Serial UI Disconnected
<img width="981" height="804" alt="Screenshot 2026-08-18 at 12 17 06 PM" src="https://github.com/user-attachments/assets/7775a8c3-4b68-4076-a12f-a6cf246481f4" />

### Serial UI Connected
<img width="977" height="816" alt="image" src="https://github.com/user-attachments/assets/aa69f876-2bfd-4e10-b6cd-e1161e6305b3" />

</details>
