### PR TITLE
OS switching for gamepad arm controls

### DIFF
--- a/src/components/gamepad/Gamepad.jsx
+++ b/src/components/gamepad/Gamepad.jsx
@@ -12,6 +12,8 @@ import { useMastCommands } from "../../contexts/MastCommandContext";
 
 import { ARM_LIMITS, ARM_DEFAULTS } from "../../constants/armConfig";
 
+import { getOS } from "./getOS";
+
 // Handles gamepad connections and state
 export default function GamepadPanel() {
   // general vars
@@ -24,6 +26,8 @@ export default function GamepadPanel() {
     setPage(location.pathname);
   }, [location.pathname]);
   const [connectedGamepads, setConnectedGamepads] = useConnectedGamepads();
+
+  const osRef = useRef(getOS());
 
   // drive
   const [_driveCommands, setDriveCommands] = useDriveCommands();
@@ -283,6 +287,7 @@ export default function GamepadPanel() {
         return;
       }
 
+      const os = osRef.current;
       const armInputs = {
         elbow: gp.buttons[2]?.pressed ? clean(gp.axes[1]) : 0,
         shoulder: gp.buttons[3]?.pressed ? -clean(gp.axes[1]) : 0,
@@ -290,26 +295,27 @@ export default function GamepadPanel() {
           (!gp.buttons[0]?.pressed && !gp.buttons[2]?.pressed && !gp.buttons[3]?.pressed)
             ? clean(gp.axes[0])
             : 0,
-        // treat full up/down as hard limits for better control at extremes
-        // windows axis
-        // pitch:
-        //   gp.axes[9] === -1
-        //     ? -1
-        //     : gp.axes[9] < 0.15 && gp.axes[9] > 0.14
-        //       ? 1
-        //       : 0,
-        // roll:
-        //   gp.axes[9] < 0.72 && gp.axes[9] > 0.71
-        //     ? -1
-        //     : gp.axes[9] < -0.42 && gp.axes[9] > -0.43
-        //       ? 1
-        //       : 0,
-        // clamp: clean(gp.axes[3]),
-        // uniSens: -0.5 * gp.axes[6] + 0.5,
-        pitch: -clean(gp.axes[5]),
-        roll: clean(gp.axes[4]),
-        clamp: gp.buttons[0]?.pressed ? -clean(gp.axes[1]) : 0,
-        uniSens: -0.5 * gp.axes[3] + 0.5,
+        ...(os === "linux" ? {
+          pitch: -clean(gp.axes[5]),
+          roll: clean(gp.axes[4]),
+          clamp: gp.buttons[0]?.pressed ? -clean(gp.axes[1]) : 0,
+          uniSens: -0.5 * gp.axes[3] + 0.5,
+        } : {
+          pitch:
+            gp.axes[9] === -1
+              ? -1
+              : gp.axes[9] < 0.15 && gp.axes[9] > 0.14
+                ? 1
+                : 0,
+          roll:
+            gp.axes[9] < 0.72 && gp.axes[9] > 0.71
+              ? -1
+              : gp.axes[9] < -0.42 && gp.axes[9] > -0.43
+                ? 1
+                : 0,
+          clamp: gp.buttons[0]?.pressed ? -clean(gp.axes[1]) : 0,
+          uniSens: -0.5 * gp.axes[6] + 0.5,
+        })
       };
 
       const inputSens = {

--- a/src/components/gamepad/getOS.js
+++ b/src/components/gamepad/getOS.js
@@ -1,0 +1,15 @@
+export function getOS() {
+    if(navigator.userAgentData?.platform) {
+        const platform = navigator.userAgentData?.platform.toLowerCase();
+        if(platform.includes("win")) return "windows";
+        if(platform.includes("mac")) return "mac";
+        if(platform.includes("linux")) return "linux";
+    }
+
+    const userAgent = navigator.userAgent.toLowerCase();
+    if(userAgent.includes("win")) return "windows";
+    if(userAgent.includes("mac")) return "mac";
+    if(userAgent.includes("linux")) return "linux";
+
+    return "unknown";
+}


### PR DESCRIPTION
- Gamepad controls for arm change to appropriate mappings based on OS
- Two mappings: Linux, everything else (confirmed for Windows and MacOS)